### PR TITLE
DI-894 - pivot to pulling data from Clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.manifest
 *.log
+*.pyc
+*.xlsx

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*.ipynb
 *.manifest
 *.log
 *.pyc
+*.tsv
 *.xlsx

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -27,6 +27,7 @@ from utils.dx_manage import (
 
 
 from utils.utils import (
+    add_test_codes_back_to_samples,
     call_in_parallel,
     filter_non_unique_specimen_ids,
     group_samples_by_project,
@@ -35,29 +36,59 @@ from utils.utils import (
 )
 
 
-def configure_inputs(samples, assay):
+def configure_inputs(samples_to_codes, assay):
     """
     Searches all 002 projects against given sample list to find
-    original project for each and
+    original project for each, check the archivalState for all
+    required files and return big dict of all data.
+
+    Returned data structure will be:
+
+    {
+        "project-xxx": {
+            "project_name": "002_240401_A01295_0334_XXYNSHDBDR",
+            "cnv_call_job_id": "job-xxx",
+            "dias_single_path": "project-xxx:/output/CEN_240401_1105",
+            "samples": [
+                {
+                    "sample": "123456-23251R0047",
+                    "instrument_id": "123456",
+                    "specimen_id": "23251R0047",
+                    "codes": ["R211"]
+                },
+                ...
+            ]
+        }
+    }
 
     Parameters
     ----------
-    samples : dict
+    samples_to_codes : dict
         mapping of specimen ID to list of test codes
+    assay : str
+        assay to run reports for
+
+    Returns
+    -------
+    dict
+        mapping of all samples and their respective data per project
     """
-    projects = list(reversed(get_projects(assay=assay)))[:5]
+    projects = get_projects(assay=assay)
 
     manual_review = defaultdict(lambda: defaultdict(list))
 
     reports = get_xlsx_reports(
-        all_samples=list(samples.keys()),
-        projects=projects
+        all_samples=list(samples_to_codes.keys()),
+        projects=projects.keys()
     )
 
     samples = parse_sample_identifiers(reports)
     samples, non_unique_specimens = filter_non_unique_specimen_ids(samples)
 
-    project_samples = group_samples_by_project(samples=samples)
+    project_samples = group_samples_by_project(
+        samples=samples,
+        projects=projects
+    )
 
     print(
         f"{len(project_samples.keys())} projects retained with samples"
@@ -66,45 +97,54 @@ def configure_inputs(samples, assay):
 
     projects_to_skip = []
 
-    for project, project_data in project_samples.items():
-        cnv_jobs = get_cnv_call_job(project=project)
-        dias_single_paths = get_single_dir(project=project)
+    for project_id, project_data in project_samples.items():
+        cnv_jobs = get_cnv_call_job(project=project_id)
+        dias_single_paths = get_single_dir(project=project_id)
 
         if len(cnv_jobs) > 1:
             print('oh no - more than one cnv job found')
-            projects_to_skip.append(project)
+            projects_to_skip.append(project_id)
             #TODO - figure out what to do, should we stop on any with issues?
             continue
         else:
-            project_samples[project]['cnv_call_job'] = cnv_jobs[0]
+            # add in CNV call job ID for current project
+            project_samples[project_id]['cnv_call_job'] = cnv_jobs[0]
 
         if len(dias_single_paths) > 1:
             print('oh no - more than one single path found')
-            projects_to_skip.append(project)
+            projects_to_skip.append(project_id)
             continue
         else:
-            project_samples[project]['dias_single_path'] = dias_single_paths[0]
+            # add in Dias single path for current project
+            project_samples[project_id]['dias_single_path'] = dias_single_paths[0]
 
         _, unarchiving, archived = check_archival_state(
-            project=project, sample_data=project_data
+            project=project_id, sample_data=project_data
         )
 
         if unarchiving or archived:
             # TODO -  figure out what to do with this projects worth of samples
+            # where there are non-live files we require
             print('Archived or unarchiving files present')
-            projects_to_skip.append(project)
+            projects_to_skip.append(project_id)
             continue
 
     # remove any projects worth of samples with issues
-    # TODO - figure out what / how to handle these for reviewing and resuming
+    # TODO - figure out what / how to handle these for reviewing and resuming,
+    # can probably pickle a load of data and resume from there
     for project in projects_to_skip:
         project_samples.pop(project)
 
+    # add back the test codes from Clarity for each sample
+    project_samples = add_test_codes_back_to_samples(
+        sample_codes=samples_to_codes,
+        project_samples=project_samples
+    )
 
-    exit()
+    return project_samples
 
 
-def generate_manifest(report_jobs, project_name, now) -> List[dict]:
+def generate_manifest(project_name, sample_data, now) -> List[dict]:
     """
     Generate data to build a manifest by querying the report jobs to get
     the sample name from the output xlsx report and the test code from
@@ -113,10 +153,10 @@ def generate_manifest(report_jobs, project_name, now) -> List[dict]:
 
     Parameters
     ----------
-    report_jobs : list
-        list of dicts of describe details for each xlsx report
     project_name : str
         name of project for naming manifest
+    sample_data : list
+        list of dicts of sample data (IDs and test code(s))
     now : str
         current datetime for naming
 
@@ -125,48 +165,31 @@ def generate_manifest(report_jobs, project_name, now) -> List[dict]:
     str
         file name of manifest generated
     """
-    print(f"Generating manifest data from {len(report_jobs)} report jobs")
-    samples_indications = defaultdict(list)
+    print(f"Generating manifest data for {len(sample_data)} samples")
 
-    sample_codes = call_in_parallel(
-        func=get_sample_name_and_test_code, items=report_jobs
-    )
+    manifest = f"{project_name}-{now}_re_run.manifest"
+    count = 0
 
-    for sample, code in sample_codes:
-        if sample and code:
-            samples_indications[sample].append(code)
+    with open(manifest, "w") as fh:
+        fh.write(
+            "batch\nInstrument ID;Specimen ID;Re-analysis Instrument ID;"
+            "Re-analysis Specimen ID;Test Codes\n"
+        )
 
-    # ensure we don't duplicate test codes for a sample
-    samples_indications = {
-        sample: list(set(codes))
-        for sample, codes in samples_indications.items()
-    }
+        for sample in sample_data:
+            for code in sample['codes']:
+                fh.write(
+                    f"{sample['instrument_id']};{sample['specimen_id']}"
+                    f";;;{code}\n"
+                )
+                count += 1
 
-    manifest = None
-
-    if samples_indications:
-        # found at least one sample report job to rerun
-        manifest = f"{project_name}-{now}_re_run.manifest"
-
-        count = 0
-
-        with open(manifest, "w") as fh:
-            fh.write(
-                "batch\nInstrument ID;Specimen ID;Re-analysis Instrument ID;"
-                "Re-analysis Specimen ID;Test Codes\n"
-            )
-
-            for sample, codes in samples_indications.items():
-                for code in codes:
-                    fh.write(f"{sample.replace('-', ';')};;;{code}\n")
-                    count += 1
-
-    print(f"{count} sample - test codes written to manifest")
+    print(f"{count} sample - test codes written to file {manifest}")
 
     return manifest
 
 
-def run_all_batch_jobs(args) -> list:
+def run_all_batch_jobs(args, all_sample_data) -> list:
     """
     Main function to configure all inputs for running dias batch against
     every 002 project
@@ -175,62 +198,34 @@ def run_all_batch_jobs(args) -> list:
     ----------
     args : argparse.Namespace
         parsed arguments from command line
+    all_sample_data : dict
+        mapping of project ID to all sample data required
 
     Returns
     -------
     list
         list of launched job IDs
     """
-    projects = get_projects(assay=args.assay)
-
-    if args.limit:
-        print(f"Limiting rerunning jobs to {args.limit} runs")
-        projects = projects[: args.limit]
-
     now = datetime.now().strftime("%y%m%d_%H%M")
 
     create_folder(path=f"/manifests/{now}")
 
     launched_jobs = []
 
-    for idx, project in enumerate(projects, 1):
-        print(
-            f"\nSearching {project['describe']['name']} for jobs "
-            f"({idx}/{len(projects)})"
-        )
-
-        single_path = get_single_dir(project=project["id"])
-        cnv_job = get_cnv_call_job(project=project["id"])
-        report_jobs = get_report_jobs(project=project["id"])
-
-        if not single_path and not cnv_job:
-            print("single path and / or cnv job not valid, skipping")
-            continue
-
-        if not report_jobs:
-            print(
-                f"No report jobs found in {project}, project will be "
-                "ignored as there is nothing to rerun"
-            )
-            continue
+    for project, project_data in all_sample_data.items():
 
         manifest = generate_manifest(
-            report_jobs=report_jobs,
-            project_name=project["describe"]["name"],
-            now=now,
+            sample_data=project_data['samples'],
+            project_name=project_data['project_name'],
+            now=now
         )
-
-        if not manifest:
-            # didn't generate any data to make a manifest file
-            print("No valid previous job data found to generate manifest file")
-            continue
 
         manifest_id = upload_manifest(
             manifest=manifest, path=f"/manifests/{now}"
         )
 
         # name for naming dias batch job
-        name = f"eggd_dias_batch_{project['describe']['name']}"
+        name = f"eggd_dias_batch_{project['project_name']}"
 
         if args.testing:
             # when testing run everything in one 003 project
@@ -240,13 +235,13 @@ def run_all_batch_jobs(args) -> list:
 
         batch_id = run_batch(
             project=batch_project,
-            cnv_job=cnv_job,
-            single_path=single_path,
+            cnv_job=project_data['cnv_call_job_id'],
+            single_path=project_data['dias_single_path'],
             manifest=manifest_id,
             name=name,
             batch_inputs=args.batch_inputs,
             assay=args.assay,
-            terminate=args.terminate,
+            terminate=args.terminate
         )
 
         launched_jobs.append(batch_id)
@@ -523,13 +518,9 @@ def main():
     else:
         samples_to_codes = parse_clarity_export(args.clarity_export)
 
-    configure_inputs(samples_to_codes, 'CEN')
+    sample_data = configure_inputs(samples_to_codes, 'CEN')
 
-
-
-
-
-    batch_job_ids = run_all_batch_jobs(args=args)
+    batch_job_ids = run_all_batch_jobs(args=args, all_sample_data=sample_data)
 
     if args.monitor and batch_job_ids:
         monitor_launched_jobs(batch_job_ids, mode="batch")

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -104,7 +104,7 @@ def configure_inputs(samples_to_codes, assay):
         if len(cnv_jobs) > 1:
             print('oh no - more than one cnv job found')
             projects_to_skip.append(project_id)
-            # TODO - figure out what to do, should we stop on any with issues?
+            #TODO - figure out what to do, should we stop on any with issues?
             continue
         else:
             # add in CNV call job ID for current project

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -104,7 +104,7 @@ def configure_inputs(samples_to_codes, assay):
         if len(cnv_jobs) > 1:
             print('oh no - more than one cnv job found')
             projects_to_skip.append(project_id)
-            #TODO - figure out what to do, should we stop on any with issues?
+            # TODO - figure out what to do, should we stop on any with issues?
             continue
         else:
             # add in CNV call job ID for current project
@@ -393,7 +393,7 @@ def parse_args() -> argparse.Namespace:
     )
     clarity = parser.add_mutually_exclusive_group(required=True)
     clarity.add_argument(
-        "--clarity_export", type=str,help=(
+        "--clarity_export", type=str, help=(
             'export from Clarity to parse samples from if not connecting'
         )
     )

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -4,29 +4,33 @@ Functions relating to managing data objects an queries in DNAnexus
 import concurrent
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Union
 
 import dxpy
 
 from .utils import call_in_parallel
 
 
-def check_archival_state(project, sample_data) -> list:
+def check_archival_state(project, sample_data) -> Union[list, list, list]:
     """
     Check the archival state of all files in a project for the given
     samples that will be required for running reports
 
     Parameters
     ----------
-    project : _type_
-        _description_
-    samples : _type_
-        _description_
+    project : list
+        list of project IDs to use as search scope
+    sample_data : list
+        list of dicts of per sample details to get samplename from
 
     Returns
     -------
     list
-        _description_
+        list of file objects in live state
+    list
+        list of file objects in unarchiving state
+    list
+        list of file objects in archived state
     """
     print("Checking archival state of required files")
 
@@ -166,7 +170,7 @@ def get_cnv_call_job(project) -> list:
 
 def get_dependent_files(project_samples):
     """
-    _summary_
+    TODO
 
     Parameters
     ----------
@@ -174,7 +178,7 @@ def get_dependent_files(project_samples):
         _description_
     """
     for project, samples in project_samples.values():
-         pass
+        pass
 
 
 def get_job_states(job_ids) -> dict:
@@ -256,19 +260,20 @@ def get_projects(assay) -> List[dict]:
 
 def get_xlsx_reports(all_samples, projects) -> list:
     """
-    _summary_
+    Return all xlsx report objects for the given samples across all the
+    given projects
 
     Parameters
     ----------
-    samples : _type_
-        _description_
-    project : _type_
-        _description_
+    samples : list
+        list of part of samplename to search for xlsx file for
+    projects : list
+        list of project IDs to search within
 
     Returns
     -------
     list
-        _description_
+        list of all xlsx file describe objects found
     """
     def get_reports(project, samples):
         """Query given sample IDs in one go to find all files"""

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -255,6 +255,9 @@ def get_projects(assay) -> List[dict]:
 
     print(f"Found {len(projects)} projects for {assay}")
 
+    # turn list of projects to dict of id: describe
+    projects = {x['id']: x['describe'] for x in list(reversed(projects))[:3]}
+
     return projects
 
 
@@ -298,7 +301,7 @@ def get_xlsx_reports(all_samples, projects) -> list:
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
             concurrent_jobs = {
-                executor.submit(get_reports, project['id'], item)
+                executor.submit(get_reports, project, item)
                 for item in all_samples
             }
 
@@ -318,7 +321,7 @@ def get_xlsx_reports(all_samples, projects) -> list:
         # flatten the returned list of lists of sample data
         project_reports = [x for y in project_reports for x in y]
         all_reports.extend(project_reports)
-        print(f"Found {len(project_reports)} reports in project {project['id']}")
+        print(f"Found {len(project_reports)} reports in project {project}")
 
     return all_reports
 

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -54,6 +54,7 @@ def check_archival_state(project, sample_data) -> list:
 
     file_details = []
 
+    #TODO - refactor this mess along with find_xlsx_reports()
     def _find(project, search_term):
         """Query given sample IDs in one go to find all files"""
         return list(dxpy.find_data_objects(
@@ -85,6 +86,8 @@ def check_archival_state(project, sample_data) -> list:
     # flatten the returned list of lists of sample data
     file_details = [x for y in file_details for x in y]
 
+
+    #TODO - return something useful from this on states
     print(f"Found {len(file_details)} files")
 
     l = set([x['describe']['archivalState'] for x in file_details])

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -42,7 +42,7 @@ def check_archival_state(project, sample_data) -> Union[list, list, list]:
         '_copy_ratios.gcnv.bed.tbi$',
         '_markdup.per-base.bed.gz$',
         '_markdup_recalibrated_Haplotyper.vcf.gz$',
-        '_markdup.reference_build.txt',
+        '_markdup.reference_build.txt$',
         'bam$',
         'bam.bai$'
     ]

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -60,7 +60,7 @@ def check_archival_state(project, sample_data) -> Union[list, list, list]:
 
     file_details = []
 
-    #TODO - refactor this mess along with find_xlsx_reports(), might be
+    # TODO - refactor this mess along with find_xlsx_reports(), might be
     # able to bodge it into the call_in_parallel function
     def _find(project, search_term):
         """Query given sample IDs in one go to find all files"""
@@ -94,7 +94,7 @@ def check_archival_state(project, sample_data) -> Union[list, list, list]:
     file_details = [x for y in file_details for x in y]
 
 
-    #TODO - return something useful from this on states
+    # TODO - return something useful from this on states
     print(f"Found {len(file_details)} files")
 
     live = [x for x in file_details if x['describe']['archivalState'] == 'live']

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -345,7 +345,7 @@ def get_single_dir(project) -> str:
     # TODO - add this to config or something
     single_dirs = {
         "project-GgXvB984QX3xF6qkPK4Kp5xx": "/output/CEN-240304_1257",
-        "project-Ggyb2G84zJ4363x2JqfGgb6J": "/output/CEN-240322_0936"
+        "project-Ggyb2G84zJ4363x2JqfGgb6J": "/output/CEN-240322_0936",
     }
 
     if single_dirs.get(project):

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -212,13 +212,13 @@ def parse_sample_identifiers(reports) -> list:
 
     Parameters
     ----------
-    reports : _type_
-        _description_
+    reports : list
+        list of file object dicts
 
     Returns
     -------
     list
-        _description_
+        list of dicts with required sample details
     """
     return [
         {   'project': x['project'],

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -220,7 +220,6 @@ def parse_sample_identifiers(reports) -> list:
     list
         _description_
     """
-    print(reports)
     return [
         {   'project': x['project'],
             'sample': x['describe']['name'].split('_')[0],

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -1,12 +1,14 @@
 """
 General utility functions
 """
-
+from collections import defaultdict
 import concurrent
 from datetime import datetime
 import re
 
 import pandas as pd
+from typing import Union
+
 
 
 def call_in_parallel(func, items) -> list:
@@ -78,7 +80,87 @@ def date_to_datetime(date) -> int:
     return (datetime.now() - start).days
 
 
-def parse_clarity_export(export_file) -> list:
+def filter_non_unique_specimen_ids(reports) -> Union[list, dict]:
+    """
+    Filter out any samples that exist in more than one 002 project by
+    specimen ID where we can't unambiguously identify them against a
+    single instrument ID. This is being done since we only extract the
+    specimen ID from Clarity.
+
+    Parameters
+    ----------
+    reports : list
+        list of sample report objects to filter down
+
+    Returns
+    -------
+    list
+        sample reports where specimen ID - instrument ID is unique
+    dict
+        mapping of specimen ID to report dict where more than one
+        instrument ID is present for a specimen ID
+    """
+    unique = []
+    non_unique = defaultdict(list)
+
+    # first map specimen to unique instrument IDs
+    sample_map = defaultdict(list)
+    for report in reports:
+        if report['instrument_id'] not in sample_map[report['specimen_id']]:
+            sample_map[report['specimen_id']].append(report['instrument_id'])
+
+    # split out reports where the specimen matches more than one instrument
+    for report in reports:
+        if len(sample_map[report['specimen_id']]) > 1:
+            non_unique[report['specimen_id']].append(report)
+        else:
+            unique.append(report)
+
+    return unique, non_unique
+
+
+def group_samples_by_project(samples) -> dict:
+    """
+    Group the list of sample reports by the project they are from.
+
+    Returns as the structure: [
+        {
+            'project-xxx': {
+                'samples': [
+                    {
+                        'id': 'file-xxx'
+                    }
+                    ...
+                ]
+            }
+        },
+        {
+            'project-yyy': {
+                ...
+
+
+    Parameters
+    ----------
+    samples : list
+        list of sample details
+
+    Returns
+    -------
+    list
+        report object lists split by project
+    """
+    project_samples = defaultdict(lambda: defaultdict(list))
+
+    for sample in samples:
+        project_samples[sample['project']]['samples'].append(sample)
+
+    return {k: dict(v) for k, v in dict(project_samples).items()}
+
+
+# def match_test_codes_to_samples(project_samples)
+
+
+def parse_clarity_export(export_file) -> dict:
     """
     Parse the xlsx export from Clarity to get the samples and test codes
 
@@ -89,8 +171,8 @@ def parse_clarity_export(export_file) -> list:
 
     Returns
     -------
-    list
-        list of tuples of specimen ID and test code(s)
+    dict
+        dict mapping specimen ID to test code(s)
     """
     clarity_df = pd.read_excel(export_file)
 
@@ -103,14 +185,46 @@ def parse_clarity_export(export_file) -> list:
     clarity_df = clarity_df[
         clarity_df['Test Directory Clinical Indication'] != 'Research Use']
 
+    clarity_df['Test Directory Clinical Indication'].fillna(value='', inplace=True)
+
     # generate list of specimen ID and test code
     # TODO - need to figure out if to use the Clinical Indication column
     # to get the test code from or the Test Code column, they seem to differ
     # so need to know which is correct
-    samples_to_codes = clarity_df[[
+    samples_to_codes = (clarity_df[[
         'Specimen Identifier', 'Test Directory Clinical Indication'
-    ]].to_records(index=False).tolist()
+    ]].to_records(index=False))
 
-    return samples_to_codes
+    # generate mapping of specimen ID to list of test codes
+    sample_code_mapping = defaultdict(list)
+
+    for sample in samples_to_codes:
+        sample_code_mapping[sample[0]].extend(str(sample[1]).split('|'))
+
+    return sample_code_mapping
 
 
+def parse_sample_identifiers(reports) -> list:
+    """
+    Return the required fields from the xlsx report file name as a dict
+    per sample of the project, full samplename, instrument ID and the
+    specimen ID
+
+    Parameters
+    ----------
+    reports : _type_
+        _description_
+
+    Returns
+    -------
+    list
+        _description_
+    """
+    print(reports)
+    return [
+        {   'project': x['project'],
+            'sample': x['describe']['name'].split('_')[0],
+            'instrument_id': x['describe']['name'].split('-')[0],
+            'specimen_id': x['describe']['name'].split('-')[1]
+        } for x in reports
+    ]

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -180,7 +180,7 @@ def add_test_codes_back_to_samples(sample_codes, project_samples) -> dict:
     dict
         per project sample data with test codes added
     """
-    project_samples_with_codes =  deepcopy(project_samples)
+    project_samples_with_codes = deepcopy(project_samples)
 
     for project_id, project_data in project_samples.items():
         for idx, sample_data in enumerate(project_data['samples']):
@@ -259,7 +259,8 @@ def parse_sample_identifiers(reports) -> list:
         list of dicts with required sample details
     """
     samples = [
-        {   'project': x['project'],
+        {
+            'project': x['project'],
             'sample': x['describe']['name'].split('_')[0],
             'instrument_id': x['describe']['name'].split('-')[0],
             'specimen_id': x['describe']['name'].split('-')[1]


### PR DESCRIPTION
- switch to pulling data in from Clarity to get outstanding samples
  - currently takes an export from Clarity as an xlsx, will hopefully in future also handle directly querying the database but we're not there yet
  - now will use the specimen IDs from Clarity (as thats all we have) and the tests codes, then query all 002 projects for the assay to get the full sample details from there. Samples are then split by project to check for files and for running batch.
  - all querying now happens with project scope to keep DNAnexus API happy (but still in parallel to not take forever) 
- find all required files for SNV/CNV reports and Artemis up front and check archival state to ensure batch will be able to just launch everything
- fit all the above back to current functionality for generating manifests and running batch
- full of messy TODOs - will get to these later with further refactoring and clean up
- current Clarity export has ~2,700 sample entries, all searching and building project-sample data takes <1 minute

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/2)
<!-- Reviewable:end -->
