### PR TITLE
DI-932 additional args for restricting total samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 *.tsv
 *.xlsx
+.~lock.*

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -119,6 +119,8 @@ def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
         projects=projects
     )
 
+    exit()
+
     projects_to_skip = []
 
     for project_id, project_data in project_samples.items():

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -38,7 +38,7 @@ from utils.utils import (
 )
 
 
-def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
+def configure_inputs(clarity_data, assay, limit, start_date, end_date):
     """
     Searches all 002 projects against given sample list to find
     original project for each, check the archivalState for all
@@ -65,7 +65,7 @@ def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
 
     Parameters
     ----------
-    samples_to_codes : dict
+    clarity_data : dict
         mapping of specimen ID to list of test codes and dates from Clarity
     assay : str
         assay to run reports for
@@ -88,7 +88,7 @@ def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
     manual_review = defaultdict(lambda: defaultdict(list))
 
     reports = get_xlsx_reports(
-        all_samples=list(samples_to_codes.keys()),
+        all_samples=list(clarity_data.keys()),
         projects=list(projects.keys())
     )
 
@@ -96,14 +96,14 @@ def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
     samples, non_unique_specimens = filter_non_unique_specimen_ids(samples)
 
     filter_clarity_samples_with_no_reports(
-        clarity_samples=samples_to_codes,
+        clarity_samples=clarity_data,
         samples_w_reports=samples
     )
 
     # add back the test codes and booked date from Clarity for each sample
     samples = add_clarity_data_back_to_samples(
         samples=samples,
-        clarity_data=samples_to_codes
+        clarity_data=clarity_data
     )
 
     if any([limit, start_date, end_date]):
@@ -118,8 +118,6 @@ def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
         samples=samples,
         projects=projects
     )
-
-    exit()
 
     projects_to_skip = []
 
@@ -560,17 +558,15 @@ def main():
     if args.clarity_connect:
         pass
     else:
-        samples_to_codes = parse_clarity_export(args.clarity_export)
+        clarity_data = parse_clarity_export(args.clarity_export)
 
     sample_data = configure_inputs(
-        samples_to_codes=samples_to_codes,
+        clarity_data=clarity_data,
         assay=args.assay,
         limit=args.limit,
         start_date=args.start_date,
         end_date=args.end_date
     )
-
-
 
     batch_job_ids = run_all_batch_jobs(args=args, all_sample_data=sample_data)
 

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -89,7 +89,7 @@ def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
 
     reports = get_xlsx_reports(
         all_samples=list(samples_to_codes.keys()),
-        projects=list(projects.keys())[:5]
+        projects=list(projects.keys())
     )
 
     samples = parse_sample_identifiers(reports)
@@ -567,6 +567,8 @@ def main():
         start_date=args.start_date,
         end_date=args.end_date
     )
+
+
 
     batch_job_ids = run_all_batch_jobs(args=args, all_sample_data=sample_data)
 

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -589,7 +589,7 @@ def main():
             print("Stopping now.")
             exit()
         else:
-            print("Invalid response")
+            print("Invalid response, please enter 'y' or 'n'")
 
     batch_job_ids = run_all_batch_jobs(args=args, all_sample_data=sample_data)
 

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -38,6 +38,9 @@ from utils.utils import (
 )
 
 
+TEST_PROJECT = "project-Ggvgj6j45jXv43B84Vfzvgv6"
+
+
 def configure_inputs(clarity_data, assay, limit, start_date, end_date):
     """
     Searches all 002 projects against given sample list to find
@@ -122,6 +125,10 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date):
     projects_to_skip = []
 
     for project_id, project_data in project_samples.items():
+        print(
+            f"\nChecking project data for {project_data['project_name']} "
+            f"({project_id})"
+        )
         cnv_jobs = get_cnv_call_job(
             project=project_id,
             selected_jobs=manual_cnv_call_jobs
@@ -246,11 +253,11 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
         )
 
         # name for naming dias batch job
-        name = f"eggd_dias_batch_{project['project_name']}"
+        name = f"eggd_dias_batch_{project_data['project_name']}"
 
         if args.testing:
             # when testing run everything in one 003 project
-            batch_project = "project-Ggvgj6j45jXv43B84Vfzvgv6"
+            batch_project = TEST_PROJECT
         else:
             batch_project = project["id"]
 
@@ -568,6 +575,22 @@ def main():
         end_date=args.end_date
     )
 
+    while True:
+        print(
+            f"Confirm running reports for all samples in "
+            f"{TEST_PROJECT if args.testing else 'original 002 projects'}"
+        )
+        confirm = input('Run jobs? ')
+
+        if confirm.lower() in ['y', 'yes']:
+            print("Beginning launching jobs...")
+            break
+        elif confirm.lower() in ['n', 'no']:
+            print("Stopping now.")
+            exit()
+        else:
+            print("Invalid response")
+
     batch_job_ids = run_all_batch_jobs(args=args, all_sample_data=sample_data)
 
     if args.monitor and batch_job_ids:
@@ -579,4 +602,5 @@ def main():
 
 
 if __name__ == "__main__":
+
     main()

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -100,28 +100,23 @@ def configure_inputs(samples_to_codes, assay, limit, start_date, end_date):
         samples_w_reports=samples
     )
 
-    project_samples = group_samples_by_project(
+    # add back the test codes and booked date from Clarity for each sample
+    samples = add_clarity_data_back_to_samples(
         samples=samples,
-        projects=projects
-    )
-
-    # add back the test codes from Clarity for each sample
-    project_samples = add_clarity_data_back_to_samples(
-        sample_codes=samples_to_codes,
-        project_samples=project_samples
+        clarity_data=samples_to_codes
     )
 
     if any([limit, start_date, end_date]):
-        project_samples = limit_samples(
-            projects_samples=project_samples,
+        samples = limit_samples(
+            samples=samples,
             limit=limit,
             start=start_date,
             end=end_date
         )
 
-    print(
-        f"{len(project_samples.keys())} projects retained with samples"
-        " to run reports for"
+    project_samples = group_samples_by_project(
+        samples=samples,
+        projects=projects
     )
 
     projects_to_skip = []

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -315,7 +315,6 @@ def get_xlsx_reports(all_samples, projects) -> list:
         all_reports.extend(project_reports)
         print(f"Found {len(project_reports)} reports in project {project}")
 
-    print(len(all_reports))
     # filter out any xlsx files found that look to also have a run ID
     # in the name => output from eggd_artemis for a single sample
     # (example run ID: 240229_A01295_0328_BHYG25DRX3)

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -307,8 +307,6 @@ def limit_samples(samples, limit, start, end) -> dict:
         f"{max(sample_dates).strftime('%Y-%m-%d')}.\n"
     )
 
-    exit()
-
     return limited_samples
 
 

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -289,9 +289,10 @@ def limit_samples(samples, limit, start, end) -> dict:
     samples = sorted(samples, key=lambda d: d['date'])
 
     for sample in samples:
-        if selected_samples >= limit:
-            print(f"Hit limit of {limit} samples to retain")
-            break
+        if limit:
+            if selected_samples >= limit:
+                print(f"Hit limit of {limit} samples to retain")
+                break
 
         if not start <= sample['date'] <= end:
             continue

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -191,8 +191,6 @@ def group_samples_by_project(samples, projects) -> dict:
     """
     project_samples = defaultdict(lambda: defaultdict(list))
 
-    print(len(samples))
-
     for sample in samples:
         project_samples[sample['project']]['samples'].append(sample)
         project_samples[sample['project']]['project_name'] = projects.get(
@@ -296,7 +294,6 @@ def limit_samples(samples, limit, start, end) -> dict:
             break
 
         if not start <= sample['date'] <= end:
-            print(f"sample not in specified date range: {sample['date']}")
             continue
 
         # sample within date range and not hit limit => select it
@@ -309,6 +306,8 @@ def limit_samples(samples, limit, start, end) -> dict:
         f"{min(sample_dates).strftime('%Y-%m-%d')}. Latest sample: "
         f"{max(sample_dates).strftime('%Y-%m-%d')}.\n"
     )
+
+    exit()
 
     return limited_samples
 


### PR DESCRIPTION
## Summary
- minor refactoring to implement new args: `--limit`, `--start_date` and `--end_date`
  - these are to be used to restrict what is rerun by total limit and / or date range
- context in https://cuhbioinformatics.atlassian.net/browse/DI-932 

## Changes
- add booked in date from Clarity in per sample data for limiting
- added user confirmation before launching anything to stop accidental running of jobs
- refactor various functions and call order to handle limiting
- example cmd line usage for 2 month period and stdout for limiting:
```
$ python3 bin/run_reports.py --assay CEN --clarity_export clarity_240417_01.xlsx --limit 100 --start_date 230601 --end_date 230801

Limiting samples retained for running reports, currently have 1211 samples from Clarity.
Limits specified:
        Maximum number samples: 100
        Date range: 2023-06-01 : 2023-08-01
Hit limit of 100 samples to retain
100 samples selected. Earliest sample: 2023-06-02. Latest sample: 2023-07-17.
```
