### PR TITLE
Remove hardcoded dias batch app ID

### DIFF
--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -8,6 +8,7 @@ import argparse
 from collections import Counter, defaultdict
 from datetime import datetime
 import json
+from os import path
 from time import sleep
 from typing import List
 
@@ -277,7 +278,12 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
 
         launched_jobs.append(batch_id)
 
-        with open(f"launched_batch_jobs_{now}.log", "a") as fh:
+        job_id_log = path.join(
+            path.dirname(path.abspath(__file__)),
+            f"../../logs/launched_batch_jobs_{now}.log"
+        )
+
+        with open(job_id_log, "a") as fh:
             fh.write(f"{batch_id}\n")
 
     print(f"Launched {len(launched_jobs)} Dias batch jobs")

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -11,7 +11,6 @@ import json
 from time import sleep
 from typing import List
 
-import dxpy
 
 from utils.dx_manage import (
     check_archival_state,

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -380,6 +380,26 @@ def get_single_dir(project, selected_paths) -> str:
     return paths
 
 
+def get_latest_dias_batch_app() -> str:
+    """
+    Get the app ID of the latest eggd_dias_batch
+
+    Returns
+    -------
+    str
+        app ID of latest version of eggd_dias_batch
+    """
+    app = list(dxpy.bindings.search.find_apps(
+        name='eggd_dias_batch',
+        name_mode='exact',
+        published=True
+    ))
+
+    assert app, "No app found for eggd_dias_batch"
+
+    return app[0][id]
+
+
 def upload_manifest(manifest, path) -> str:
     """
     Upload manifest file to DNAnexus

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -388,6 +388,11 @@ def get_latest_dias_batch_app() -> str:
     -------
     str
         app ID of latest version of eggd_dias_batch
+
+    Raises
+    ------
+    AssertionError
+        Raised if no matching app found
     """
     app = list(dxpy.bindings.search.find_apps(
         name='eggd_dias_batch',

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -400,6 +400,72 @@ def get_latest_dias_batch_app() -> str:
     return app[0][id]
 
 
+def run_batch(
+    project,
+    batch_app_id,
+    cnv_job,
+    single_path,
+    manifest,
+    name,
+    batch_inputs,
+    assay,
+    terminate,
+    ) -> str:
+    """
+    Runs dias batch in the specified project
+
+    Parameters
+    ----------
+    project : str
+        project ID of where to run dias batch
+    batch_app_id : str
+        app ID of latest version of eggd_dias_batch
+    cnv_job : str | None
+        job ID of CNV calling to pass to batch
+    single_path : str
+        path to Dias single output
+    manifest : str
+        file ID of uploaded manifest
+    name : str
+        name to use for batch job
+    batch_inputs : dict
+        dict of additional inputs to provide to dias_batch
+    assay : str
+        assay running analysis for
+    terminate : bool
+        controls if to terminate jobs launched by dias batch (for testing)
+
+    Returns
+    -------
+    str
+        job ID of launched dias batch job
+    """
+    # only run CNV reports if we have a CNV job ID
+    cnv_reports = True if cnv_job else False
+
+    app_input = {
+        "cnv_call_job_id": cnv_job,
+        "cnv_reports": cnv_reports,
+        "snv_reports": True,
+        "artemis": True,
+        "manifest_files": [{"$dnanexus_link": manifest}],
+        "single_output_dir": single_path,
+        "assay": assay,
+        "testing": terminate,
+    }
+
+    if batch_inputs:
+        app_input = {**app_input, **batch_inputs}
+
+    job = dxpy.DXApp(batch_app_id).run(
+        app_input=app_input, project=project, name=name
+    )
+
+    print(f"Launched dias batch job {job.id} in {project}")
+
+    return job.id
+
+
 def upload_manifest(manifest, path) -> str:
     """
     Upload manifest file to DNAnexus


### PR DESCRIPTION
## Summary
removes hard coded app ID for eggd_dias_batch

## Changes
- add function `dx_manage.get_latest_dias_batch_app()` to return app ID of latest version
- move `run_batch()` to `dx_manage`
- move log of launched job IDs to be written into `logs/` dir

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/11)
<!-- Reviewable:end -->
