### PR TITLE
Tests for dx_manage.find_in_parallel

### DIFF
--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -173,11 +173,11 @@ def find_in_parallel(project, items, prefix='', suffix='') -> list:
     list
         list of all found dxpy object details
     """
-    def _find(project, search_term):
+    def _find(project, search_terms):
         """Query given patterns as a regex search term to find all files"""
         return list(dxpy.find_data_objects(
             project=project,
-            name=rf'{prefix}{"|".join(search_term)}{suffix}',
+            name="|".join([f"{prefix}{x}{suffix}" for x in search_terms]),
             name_mode='regexp',
             describe={
                 'fields': {

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -1,7 +1,9 @@
 """Tests for dx_manage"""
+import concurrent
 import unittest
 from unittest.mock import patch
 
+import dxpy
 import pytest
 
 from bin.utils import dx_manage
@@ -150,10 +152,126 @@ class TestCreateFolder(unittest.TestCase):
     pass
 
 
+@patch('bin.utils.dx_manage.dxpy.find_data_objects')
+@patch(
+    'bin.utils.dx_manage.concurrent.futures.ThreadPoolExecutor.submit',
+    wraps=concurrent.futures.ThreadPoolExecutor().submit
+)
 class TestFindInParallel(unittest.TestCase):
-    """ """
+    """
+    Tests for dx_manage.find_in_parallel
 
-    pass
+    Function takes a project and list of search terms for which to
+    search for data objects. Searching is done with a ThreadPool of
+    32 concurrent threads for speedy searching.
+    """
+
+    def test_items_correctly_chunked(self, mock_submit, mock_find):
+        """
+        Test that when a large number of items are passed in that these
+        are correctly chunked into lists of 100 items. This is done
+        to generate a regex pattern of up to 100 patterns for a single
+        call of dxpy.find_data_objects to reduce the total API calls
+        in favour of more 'expensive' calls (i.e. more API server load
+        per call).
+
+        To test this, we will generate a list of items of 350 and use
+        the number of calls to ThreadPoolExecutor.submit() as a proxy
+        to know we have correctly chunked this to 4 lists.
+        """
+        dx_manage.find_in_parallel(
+            project='project-xxx',
+            items=[f"sample_{x}" for x in range(350)]
+        )
+
+        assert mock_submit.call_count == 4, (
+            'items not correctly chunked for concurrent searching'
+        )
+
+    def test_results_correctly_returned_as_single_list(self, mock_submit, mock_find):
+        """
+        Test that when we call the find in parallel that we correctly
+        just return a single list of items returned from the find.
+
+        Lazily just return the same for all _find calls and check length
+        """
+        mock_find.return_value = ['foo', 'bar', 'baz']
+
+        output = dx_manage.find_in_parallel(
+            project='project-xxx',
+            items=[f"sample_{x}" for x in range(350)]
+        )
+
+        # we have 4 concurrent threads => 4 calls, each has a return of
+        # length 3 items => expect a single list of 12 items
+        with self.subTest("correct length"):
+            assert len(output) == 12
+
+        with self.subTest("correct types"):
+            # test for correctly flattened to single list
+            assert all([type(x) == str for x in output])
+
+
+    def test_exceptions_caught_and_raised(self, mock_submit, mock_find):
+        """
+        Test that if one of the searches raises an Exception that this
+        is caught and raised
+        """
+        # raise error one out of 4 of the _find calls
+        mock_find.side_effect = [
+            ['foo'],
+            ['bar'],
+            dxpy.exceptions.DXError,  # generic dxpy error
+            ['baz']
+        ]
+
+        with pytest.raises(dxpy.exceptions.DXError):
+            dx_manage.find_in_parallel(
+                project='project-xxx',
+                items=[f"sample_{x}" for x in range(350)]
+            )
+
+
+    def test_find_input_args(self, mock_submit, mock_find):
+        """
+        Test that the input arg for the search term to
+        dxpy.find_data_objects is as expected with no prefix or suffix
+        """
+        dx_manage.find_in_parallel(
+            project='project-xxx',
+            items=[f"sample_{x}" for x in range(5)],
+
+        )
+
+        expected_pattern = "sample_0|sample_1|sample_2|sample_3|sample_4"
+
+        # mocked function args are stored as 2nd item in tuple
+        name_arg = mock_find.call_args[1]['name']
+
+        assert name_arg == expected_pattern, "search pattern incorrect"
+
+
+    def test_find_input_args_with_prefix_suffix(self, mock_submit, mock_find):
+        """
+        Test that the input arg for the search term to
+        dxpy.find_data_objects is as expected with prefix and suffix
+        """
+        dx_manage.find_in_parallel(
+            project='project-xxx',
+            items=[f"sample_{x}" for x in range(5)],
+            prefix="foo_",
+            suffix=".bar"
+        )
+
+        expected_pattern = (
+            "foo_sample_0.bar|foo_sample_1.bar|foo_sample_2.bar|"
+            "foo_sample_3.bar|foo_sample_4.bar"
+        )
+
+        # mocked function args are stored as 2nd item in tuple
+        name_arg = mock_find.call_args[1]['name']
+
+        assert name_arg == expected_pattern, "search pattern incorrect"
 
 
 class TestGetCnvCallJob(unittest.TestCase):


### PR DESCRIPTION
- adds unit tests for `dx_manage.find_in_parallel`
- fixes search patterns to correctly apply prefix and suffix to each pattern

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/27)
<!-- Reviewable:end -->
