### PR TITLE
Additional pytest plugins

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = tests/*
+

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,4 +18,4 @@ jobs:
         pipenv install --dev
     - name: Test with pytest
       run: |
-        pytest -vv --cov
+        pytest -vv --cov --count 10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,4 +18,4 @@ jobs:
         pipenv install --dev
     - name: Test with pytest
       run: |
-        pytest -vv --cov --count 10 --random-order
+        pytest -v --cov --count 10 --random-order bin/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,5 +18,5 @@ jobs:
         pipenv install --dev
     - name: Test with pytest
       run: |
-        pwd
-        python -m pytest -v --cov --count 10 --random-order dias_reports_bulk_reanalysis/bin/
+        pytest -v --cov --count 10 --random-order
+  

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,4 +18,5 @@ jobs:
         pipenv install --dev
     - name: Test with pytest
       run: |
-        python -m pytest -v --cov --count 10 --random-order bin/
+        pwd
+        python -m pytest -v --cov --count 10 --random-order dias_reports_bulk_reanalysis/bin/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,4 +18,4 @@ jobs:
         pipenv install --dev
     - name: Test with pytest
       run: |
-        pytest -v --cov --count 10 --random-order bin/
+        python -m pytest -v --cov --count 10 --random-order bin/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,4 +18,4 @@ jobs:
         pipenv install --dev
     - name: Test with pytest
       run: |
-        pytest -vv --cov --count 10
+        pytest -vv --cov --count 10 --random-order

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.tsv
 *.xlsx
 .~lock.*
+.coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pytest-cov==4.0.0
 pytest-html==4.1.0
 pytest-metadata==3.0.0
 pytest-mock==3.11.1
+pytest-repeat==0.9.3
 pytest-subtests==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pytest-cov==4.0.0
 pytest-html==4.1.0
 pytest-metadata==3.0.0
 pytest-mock==3.11.1
+pytest-random-order==1.1.1
 pytest-repeat==0.9.3
 pytest-subtests==0.11.0


### PR DESCRIPTION
- adds [pytest-random-order](https://pypi.org/project/pytest-random-order/) to run tests in random order to ensure no interdependence on other tests to pass
- adds [pytest-repeat](https://pypi.org/project/pytest-repeat/) to run tests repeatedly (set to 10) to try detect non-deterministic behaviour that may be missed from running the test a single time
- add `.coveragerc` to exclude test files from coverage calculation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/32)
<!-- Reviewable:end -->
