### PR TITLE
add tests for dx_manage.upload_manifest

### DIFF
--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -631,4 +631,4 @@ def upload_manifest(manifest, path) -> str:
     # clean up our generated local file
     os.remove(manifest)
 
-    return remote_file._dxid
+    return remote_file.get_id()

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -616,8 +616,8 @@ def upload_manifest(manifest, path) -> str:
     ----------
     manifest : str
         filename of manifest to upload
-    now : str
-        current datetime for folder naming
+    path : str
+        remote path to upload file to
 
     Returns
     -------
@@ -631,4 +631,4 @@ def upload_manifest(manifest, path) -> str:
     # clean up our generated local file
     os.remove(manifest)
 
-    return remote_file.id
+    return remote_file._dxid


### PR DESCRIPTION
- adds test for `dx_manage.upload_manifest`
- switch returning `.id` to using `.get_id()` method from DXFile object for easier testing
- fix incorrect docstring param

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/36)
<!-- Reviewable:end -->
