### PR TITLE
Additional unit tests for 100% coverage on dx_manage

### DIFF
--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -251,19 +251,6 @@ def get_cnv_call_job(project, selected_jobs) -> list:
     return jobs
 
 
-def get_dependent_files(project_samples):
-    """
-    TODO
-
-    Parameters
-    ----------
-    project_samples : _type_
-        _description_
-    """
-    for project, samples in project_samples.values():
-        pass
-
-
 def get_job_states(job_ids) -> dict:
     """
     Query the state of given set of job/analysis IDs

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -506,7 +506,6 @@ class TestGetJobStates(unittest.TestCase):
         assert returned_states == expected_states, "job states incorrectly parsed"
 
 
-
 @patch('bin.utils.dx_manage.dxpy.describe')
 class TestGetLaunchedWorkflowIds(unittest.TestCase):
     """
@@ -590,7 +589,6 @@ class TestGetLaunchedWorkflowIds(unittest.TestCase):
         )
 
 
-
 class TestGetProjects(unittest.TestCase):
     """
     Tests for dx_manage.get_projects
@@ -666,22 +664,26 @@ class TestGetXlsxReports(unittest.TestCase):
 
         assert mock_parallel.call_count == 3, "not called for all projects"
 
-    #TODO - come back to this after tests for find_in_parallel fixed
-    # @patch('bin.utils.dx_manage.dxpy.find_data_objects')
-    # def test_correct_search_pattern_generated(self, mock_find):
-    #     """
-    #     Test that the search pattern built in dx_manage.find_in_parallel
-    #     that is provided to dxpy.find_data_objects is as expected
-    #     """
-    #     dx_manage.get_xlsx_reports(
-    #         all_samples=self.samples,
-    #         projects=self.projects
-    #     )
+    @patch('bin.utils.dx_manage.dxpy.find_data_objects')
+    def test_correct_search_pattern_generated(self, mock_find):
+        """
+        Test that the search pattern built in dx_manage.find_in_parallel
+        that is provided to dxpy.find_data_objects is as expected
+        """
+        dx_manage.get_xlsx_reports(
+            all_samples=self.samples,
+            projects=self.projects
+        )
 
-    #     # mocked function args are stored as 2nd item in tuple
-    #     print(mock_find.call_args[1]['name'])
+        # mocked function passed arguments are stored as 2nd item in tuple
+        built_pattern = mock_find.call_args[1]['name']
 
-    #     exit(1)
+        expected_pattern = ".*sample_1.*xlsx|.*sample_2.*xlsx|.*sample_3.*xlsx"
+
+        assert built_pattern == expected_pattern, (
+            "Search pattern not as expected"
+        )
+
 
     @patch('bin.utils.dx_manage.find_in_parallel')
     def test_non_sample_xlsx_correctly_filtered_out(self, mock_parallel):
@@ -877,7 +879,6 @@ class TestGetLatestDiasBatchApp(unittest.TestCase):
         assert app_id == 'app-GfG4Bf84QQg40v7Y6zKF34KP', (
             'latest app ID incorrectly returned'
         )
-
 
 
 class TestRunBatch(unittest.TestCase):

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -940,7 +940,7 @@ class TestRunBatch(unittest.TestCase):
         additional arguments to dias batch from the cmd line args that
         these are passed into the app input
         """
-                # example input args for dx_manage.run_batch
+        # example input args for dx_manage.run_batch
         inputs = {
             'project': 'project-xxx',
             'batch_app_id': 'app-xxx',

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -272,9 +272,28 @@ class TestUnarchiveFiles(unittest.TestCase):
 
 
 class TestCreateFolder(unittest.TestCase):
-    """ """
+    """
+    Tests for dx_manage.create_folder
 
-    pass
+    This is a relatively pointless test since its a single method call
+    with no return value or any other logic, but I want that dopamine
+    hit of seeing 100% coverage, so here we are ¯\_(ツ)_/¯
+    """
+    @patch('bin.utils.dx_manage.dxpy.bindings.dxproject.DXProject')
+    def test_create_folder_called(self, mock_project):
+        """
+        Test that dxpy.bindings.dxproject.DXProject.new_folder is called
+        """
+        dx_manage.create_folder(path='/test_dir')
+
+        with self.subTest('DXProject.new_folder called'):
+            assert mock_project.return_value.new_folder.call_count == 1
+
+        with self.subTest('path passed to DXProject.new_folder'):
+            args = mock_project.return_value.new_folder.call_args[1]
+
+            assert args['folder'] == '/test_dir'
+
 
 
 @patch('bin.utils.dx_manage.dxpy.find_data_objects')

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -453,12 +453,6 @@ class TestGetCnvCallJob(unittest.TestCase):
         )
 
 
-class TestGetDependentFiles(unittest.TestCase):
-    """ """
-
-    pass
-
-
 class TestGetJobStates(unittest.TestCase):
     """
     Tests for dx_manage.get_job_states


### PR DESCRIPTION
- add unit tests for `dx_manage.get_xlsx_reports`,  `dx_manage.run_batch` and `dx_manage.create_folder`
- remove `dx_manage.get_dependent_files` since not needed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/38)
<!-- Reviewable:end -->
