### PR TITLE
Improve logging of launched jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,54 @@ python3 bin/run_reports.py --assay CEN --clarity_export <export.xlsx>
 * `--testing` (optional): Controls where dias batch is run, when testing launch all in one 003 project
 * `--terminate` (optional): Controls if to terminate all analysis jobs dias batch launches
 * `--monitor` (optional): Controls if to monitor and report on state of launched dias batch jobs
+
+## Logging
+
+When jobs have been launched a json log file is generated with the name format `launched_jobs_{yymmdd_hhmm}_log.json`. This stores the job IDs of the launched dias_batch and dias_reports_workflows jobs, allowing for querying the state and accessing output files.
+
+The log file is structured as follows:
+```
+{
+    "dias_batch": [
+        "job-Gp3vXPQ4BgGVFxJ76VG89ZbG",
+        "job-Gp8Y5Z84ZB47zXq3JJG3qvB0",
+        "job-GpFk6pj4z9pgpy7pKGx44KP3",
+        "job-GpP3kjj49kjyFG16JPJ59jBV"
+    ],
+    "dias_reports": [
+        "analysis-GpP4gy849kjxGY2YGy7117B2",
+        "analysis-GpP4gy049kjfgJ290YPG803B",
+        "analysis-GpP4gxQ49kjfgJ290YPG8030",
+        "analysis-GpP4gx849kjX9bjk9XjF6K8q"
+    ],
+    "eggd_artemis": [
+        "job-GpFp6v84z9pYz690YgkP7JJX"
+    ]
+}
+```
+
+### Example useful commands to query the log file:
+
+* check the state of dias_batch jobs:
+```
+$ jq -r '.dias_batch[]' launched_jobs_240729_1035_log.json | xargs -P16 -I{} sh -c "dx describe --json {} | jq -r '[.id,.state] | @tsv'"
+job-GpP3kjj49kjyFG16JPJ59jBV    done
+job-Gp8Y5Z84ZB47zXq3JJG3qvB0    done
+job-Gp3vXPQ4BgGVFxJ76VG89ZbG    done
+job-GpFk6pj4z9pgpy7pKGx44KP3    done
+```
+
+* check the state of dias_reports jobs:
+```
+$ jq -r '.dias_reports[]' launched_jobs_240729_1035_log.json | xargs -P16 -I{} sh -c "dx describe --json {} | jq -r '[.id,.state] | @tsv'"
+analysis-GpP4gy049kjfgJ290YPG803B       done
+analysis-GpP4gxQ49kjfgJ290YPG8030       done
+analysis-GpP4gx849kjX9bjk9XjF6K8q       done
+analysis-GpP4gy849kjxGY2YGy7117B2       done
+```
+
+* check the state of eggd_artemis jobs:
+```
+$ jq -r '.eggd_artemis[]' launched_jobs_240729_1035_log.json | xargs -P16 -I{} sh -c "dx describe --json {} | jq -r '[.id,.state] | @tsv'"
+job-GpFp6v84z9pYz690YgkP7JJX    done
+```

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -40,7 +40,8 @@ from utils.utils import (
     parse_config,
     parse_clarity_export,
     parse_sample_identifiers,
-    validate_test_codes
+    validate_test_codes,
+    write_to_log
 )
 
 
@@ -596,15 +597,30 @@ def main():
         else:
             print("Invalid response, please enter 'y' or 'n'")
 
+    now = datetime.datetime.today().strftime('%y%m%d_%H%M')
+    launched_job_log = f"launched_jobs_{now}_log.json"
+
     batch_job_ids = run_all_batch_jobs(args=args, all_sample_data=sample_data)
+
+    write_to_log(
+        log_file=launched_job_log,
+        key='dias_batch',
+        job_ids=batch_job_ids
+    )
 
     if args.monitor and batch_job_ids:
         monitor_launched_jobs(batch_job_ids, mode="batch")
 
         # monitor the launched reports workflows
         report_ids = get_launched_workflow_ids(batch_job_ids)
-        monitor_launched_jobs(report_ids, mode="reports")
 
+        write_to_log(
+            log_file=launched_job_log,
+            key='dias_reports',
+            job_ids= report_ids
+        )
+
+        monitor_launched_jobs(report_ids, mode="reports")
 
 if __name__ == "__main__":
 

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -612,12 +612,18 @@ def main():
         monitor_launched_jobs(batch_job_ids, mode="batch")
 
         # monitor the launched reports workflows
-        report_ids = get_launched_workflow_ids(batch_job_ids)
+        artemis_ids, report_ids = get_launched_workflow_ids(batch_job_ids)
 
         write_to_log(
             log_file=launched_job_log,
             key='dias_reports',
             job_ids= report_ids
+        )
+
+        write_to_log(
+            log_file=launched_job_log,
+            key='eggd_artemis',
+            job_ids= artemis_ids
         )
 
         monitor_launched_jobs(report_ids, mode="reports")

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -276,7 +276,7 @@ def get_job_states(job_ids) -> dict:
 
 def get_launched_workflow_ids(batch_ids) -> Union[list, list]:
     """
-    Get analysis IDs of launched Dias reports and eggd_artemis
+    Get analysis IDs of launched Dias reports and job ID of eggd_artemis
 
     Parameters
     ----------

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -274,9 +274,9 @@ def get_job_states(job_ids) -> dict:
     return job_state
 
 
-def get_launched_workflow_ids(batch_ids) -> list:
+def get_launched_workflow_ids(batch_ids) -> Union[list, list]:
     """
-    Get analysis IDs of launched Dias reports
+    Get analysis IDs of launched Dias reports and eggd_artemis
 
     Parameters
     ----------
@@ -285,6 +285,9 @@ def get_launched_workflow_ids(batch_ids) -> list:
 
     Returns
     -------
+    list
+        list of eggd_artemis jobs, n.b. this should always be a single
+        job but keeping this as a list to handle future changes
     list
         list of reports analysis IDs
     """
@@ -301,7 +304,12 @@ def get_launched_workflow_ids(batch_ids) -> list:
     report_jobs = [jobs.split(",") for jobs in report_jobs]
     report_jobs = [job for jobs in report_jobs for job in jobs]
 
-    return report_jobs
+    # the only single jobs *should* be eggd_artemis here since we aren't
+    # running CNV calling, split this from the reports jobs
+    artemis_jobs = [x for x in report_jobs if x.startswith('job-')]
+    report_jobs = [x for x in report_jobs if x.startswith('analysis-')]
+
+    return artemis_jobs, report_jobs
 
 
 def get_projects(assay) -> List[dict]:

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -576,3 +576,45 @@ def validate_test_codes(all_sample_data, genepanels):
         )
     else:
         print("All sample test codes valid!")
+
+
+def write_to_log(log_file, key, job_ids) -> None:
+    """
+    Writes given job IDs as an array to output JSON log file under the
+    specified key name
+
+    Parameters
+    ----------
+    log_file : str
+        file name of JSON log to write
+    key : str
+        name of field to write job IDs to
+    job_ids : list
+        list of job IDs to write
+
+    Raises
+    ------
+    AssertionError
+        Raised if given log_file is not a json
+    """
+    assert log_file.endswith('.json'), (
+        f'Specified log file {log_file} does not have a .json suffix'
+    )
+
+    log_file = path.abspath(path.join(
+        path.dirname(path.abspath(__file__)),
+        f"../../logs/{log_file}"
+    ))
+
+    if path.exists(log_file):
+        with open(log_file, 'r') as fh:
+            log_data = json.load(fh)
+    else:
+        log_data = {}
+
+    log_data[key] = job_ids
+
+    with open(log_file, 'w') as fh:
+        json.dump(log_data, fh)
+
+    print(f"Launched jobs IDs  for {key} written to {log_file}")

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -538,27 +538,38 @@ class TestGetLaunchedWorkflowIds(unittest.TestCase):
                 'id': 'job-xxx',
                 'state': 'done',
                 'output': {
-                    'launched_jobs': 'job-aaa,job-bbb,job-ccc'
+                    'launched_jobs': 'job-aaa,analysis-aaa,analysis-bbb'
                 }
             },
             {
                 'id': 'job-yyy',
                 'state': 'done',
                 'output': {
-                    'launched_jobs': 'job-ddd,job-eee,job-fff'
+                    'launched_jobs': 'job-bbb,analysis-ccc,analysis-ddd'
                 }
             }
         ]
 
-        returned_jobs = dx_manage.get_launched_workflow_ids(
+        returned_jobs, returned_reports = dx_manage.get_launched_workflow_ids(
             ['job-xxx', 'job-yyy']
         )
 
-        expected_jobs = [
-            'job-aaa', 'job-bbb', 'job-ccc', 'job-ddd', 'job-eee', 'job-fff'
+        expected_artemis_jobs = [
+            'job-aaa', 'job-bbb'
         ]
 
-        assert returned_jobs == expected_jobs, 'launched jobs returned incorrect'
+        expected_reports_analyses = [
+            'analysis-aaa',
+            'analysis-bbb',
+            'analysis-ccc',
+            'analysis-ddd'
+        ]
+
+        with self.subTest('artemis jobs correct'):
+            assert returned_jobs == expected_artemis_jobs
+
+        with self.subTest('reports workflows correct'):
+            assert returned_reports == expected_reports_analyses
 
 
     def test_no_launched_jobs_returns_empty_list(self, mock_decribe):
@@ -566,9 +577,9 @@ class TestGetLaunchedWorkflowIds(unittest.TestCase):
         Test when there are no batch jobs that the function just returns
         an empty list
         """
-        output = dx_manage.get_launched_workflow_ids([])
+        jobs, analyses = dx_manage.get_launched_workflow_ids([])
 
-        assert output == [], 'output incorrect for no input jobs'
+        assert (jobs, analyses) == ([], []), 'output incorrect for no input jobs'
 
 
     def test_failed_jobs_ignored(self, mock_describe):
@@ -581,7 +592,7 @@ class TestGetLaunchedWorkflowIds(unittest.TestCase):
                 'id': 'job-xxx',
                 'state': 'done',
                 'output': {
-                    'launched_jobs': 'job-aaa,job-bbb,job-ccc'
+                    'launched_jobs': 'job-aaa,analysis-aaa,analysis-bbb'
                 }
             },
             {
@@ -591,15 +602,18 @@ class TestGetLaunchedWorkflowIds(unittest.TestCase):
             }
         ]
 
-        returned_jobs = dx_manage.get_launched_workflow_ids(
+        returned_jobs, returned_analyses = dx_manage.get_launched_workflow_ids(
             ['job-xxx', 'job-yyy']
         )
 
-        expected_jobs = ['job-aaa', 'job-bbb', 'job-ccc']
+        expected_jobs = ['job-aaa']
+        expected_analyses = ['analysis-aaa', 'analysis-bbb']
 
-        assert returned_jobs == expected_jobs, (
-            "wrong job IDs returned with failed dias batch job"
-        )
+        with self.subTest('artemis jobs correct'):
+            assert returned_jobs == expected_jobs
+
+        with self.subTest('reports workflows correct'):
+            assert returned_analyses == expected_analyses
 
 
 class TestGetProjects(unittest.TestCase):
@@ -1165,5 +1179,4 @@ class TestUploadManifest(unittest.TestCase):
         assert file_id == 'file-GgQP6X84bjX3J53Vv1Yxyz7b', (
             "uploaded file ID incorrect"
         )
-
 


### PR DESCRIPTION
- improves logging of launched job IDs into a json file for storing and querying state / output files after launching
- add new function `utils.write_to_log()`
- add unit tests for new function
- adjust `dx_manage.get_launched_workflow_ids()` to split eggd_artemis job IDs from dias_reports
- adjust unit tests for above change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/41)
<!-- Reviewable:end -->
