### PR TITLE
Get multiqc reports for input to dias batch

### DIFF
--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -159,7 +159,6 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
         )
 
         multiqc_report = get_multiqc_report(
-            project=project_id,
             single_path=dias_single_paths[0]
         )
 

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -23,6 +23,7 @@ from utils.dx_manage import (
     get_projects,
     get_xlsx_reports,
     get_single_dir,
+    get_multiqc_report,
     get_latest_dias_batch_app,
     run_batch,
     upload_manifest,
@@ -140,6 +141,7 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
     # dict we will build up of project ID -> issues, will include:
     # - unhandled instances of multiple CNV call jobs or Dias single
     # - unarchiving / archived files
+    # - missing / multiple multiQC reports in given single dir
     manual_review = defaultdict(dict)
 
     for project_id, project_data in project_samples.items():
@@ -156,6 +158,11 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
             selected_paths=manual_dias_single_paths
         )
 
+        multiqc_report = get_multiqc_report(
+            project=project_id,
+            single_path=dias_single_paths[0]
+        )
+
         if len(cnv_jobs) > 1:
             # unhandled multiple CNV call job => throw in error bucket
             manual_review[project_id]['cnv_call'] = cnv_jobs
@@ -168,6 +175,15 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
             manual_review[project_id]['dias_single'] = dias_single_paths
         else:
             project_samples[project_id]['dias_single'] = dias_single_paths[0]
+
+        # verify found single multiQC report in single dir
+        if len(multiqc_report) == 0:
+            manual_review[project_id]['multiqc'] = None
+        elif len(multiqc_report) > 1:
+            manual_review[project_id]['multiqc'] = multiqc_report
+        else:
+            project_samples[project_id]['multiqc'] = multiqc_report[0]
+
 
         _, unarchiving, archived = check_archival_state(
             project=project_id, sample_data=project_data
@@ -212,6 +228,12 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
                 print(
                     f"\t{len(issues.get('archived'))} required files are in "
                     "an archived state"
+                )
+
+            if issues.get('multiqc'):
+                print(
+                    "Did not find single multiQC report in project: "
+                    f"{issues.get('multiqc')}"
                 )
 
         if unarchive and [x.get('archived') for x in manual_review.values()]:

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -392,7 +392,7 @@ def get_xlsx_reports(all_samples, projects) -> list:
     return all_reports
 
 
-def get_single_dir(project, selected_paths) -> str:
+def get_single_dir(project, selected_paths) -> list:
     """
     Find the Dias single output directory in the project
 
@@ -406,8 +406,8 @@ def get_single_dir(project, selected_paths) -> str:
 
     Returns
     -------
-    str
-        Dias single output path
+    list
+        list of Dias single output path(s)
     """
     if selected_paths.get(project):
         path = f"{project}:{selected_paths.get(project)}"

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -438,6 +438,38 @@ def get_single_dir(project, selected_paths) -> str:
     return paths
 
 
+def get_multiqc_report(project, single_path) -> list:
+    """
+    Finds the multiQC report in the given Dias single path
+
+    Parameters
+    ----------
+    project : str
+        project ID of DNAnexus project to search
+    snv_path : str
+        path to snv reports
+
+    Returns
+    -------
+    list
+        file ID(s) of the multiqc file(s)
+    """
+    print(f'searching for multiqc reports')
+    reports = list(dxpy.find_data_objects(
+        project=project,
+        folder=single_path,
+        name="*-multiqc.html",
+        name_mode='glob',
+        describe=True
+    ))
+
+    dxpy.bindings.search.find_data_objects()
+
+    print(f'reports found: {[x["id"] for x in reports]}')
+
+    return [x['id'] for x in reports]
+
+
 def get_latest_dias_batch_app() -> str:
     """
     Get the app ID of the latest eggd_dias_batch

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -438,14 +438,12 @@ def get_single_dir(project, selected_paths) -> list:
     return paths
 
 
-def get_multiqc_report(project, single_path) -> list:
+def get_multiqc_report(single_path) -> list:
     """
     Finds the multiQC report in the given Dias single path
 
     Parameters
     ----------
-    project : str
-        project ID of DNAnexus project to search
     snv_path : str
         path to snv reports
 
@@ -454,18 +452,15 @@ def get_multiqc_report(project, single_path) -> list:
     list
         file ID(s) of the multiqc file(s)
     """
-    print(f'searching for multiqc reports')
+    project, path = single_path.split(':')
+
     reports = list(dxpy.find_data_objects(
         project=project,
-        folder=single_path,
+        folder=path,
         name="*-multiqc.html",
         name_mode='glob',
         describe=True
     ))
-
-    dxpy.bindings.search.find_data_objects()
-
-    print(f'reports found: {[x["id"] for x in reports]}')
 
     return [x['id'] for x in reports]
 

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -421,7 +421,7 @@ def parse_sample_identifiers(reports) -> list:
     # that won't pass the below parsing
     invalid = [
         x['describe']['name'] for x in reports if not
-        re.match(r'[\w]+-[\w\-]+_[\w\-\.]+\.xlsx', x['describe']['name'])
+        re.match(r'[\w]+-[\w\-]+_[\w\-\.:]+\.xlsx', x['describe']['name'])
     ]
 
     if invalid:

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -509,7 +509,7 @@ def split_genepanels_test_codes(genepanels) -> pd.DataFrame:
     return genepanels
 
 
-def validate_test_codes(all_sample_data, genepanels):
+def validate_test_codes(all_sample_data, genepanels) -> None:
     """
     Parse through manifest dict of sampleID -> test codes to check
     all codes are valid and exclude those that are invalid against
@@ -532,6 +532,7 @@ def validate_test_codes(all_sample_data, genepanels):
     RuntimeError
         Raised if any invalid test codes requested for one or more samples
     """
+    return
     print("\n \nChecking test codes in manifest are valid")
     invalid = defaultdict(list)
 

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -532,7 +532,6 @@ def validate_test_codes(all_sample_data, genepanels) -> None:
     RuntimeError
         Raised if any invalid test codes requested for one or more samples
     """
-    return
     print("\n \nChecking test codes in manifest are valid")
     invalid = defaultdict(list)
 

--- a/configs/manually_selected.json
+++ b/configs/manually_selected.json
@@ -7,7 +7,8 @@
         "project-GXZg37j4kgGxFZ29fj3f3Yp4": "job-GXby1ZQ4kgGXQK7gyv506Xj9",
         "project-GXZg0J04BXfPFFZYYFGz42bP": "job-GXbyZ104BXf8G5296g93bvx2",
         "project-GjFx5VQ48q2Bj4BQ5ZgfZJQx": "job-GjGbV4848q2F8P0419V093vJ",
-        "project-GkQv26j4Q5Yzk2VjK9bXgxFb": "job-GkVKff84Q5YzYJPP8VK4v4P6"
+        "project-GkQv26j4Q5Yzk2VjK9bXgxFb": "job-GkVKff84Q5YzYJPP8VK4v4P6",
+        "project-Gkjp3K04PyP8k9VKv3x919zQ": "job-GkpZ6kj4PyP5xY9Xz0395Pgg"
     },
     "dias_single_paths": {
         "project-GgXvB984QX3xF6qkPK4Kp5xx": "/output/CEN-240304_1257",

--- a/configs/manually_selected.json
+++ b/configs/manually_selected.json
@@ -5,7 +5,9 @@
         "project-GZk71GQ446x5YQkjzvpYFBzB": "job-GZq727Q446x28FQ74BkqBJx9",
         "project-GZ3zJBj4X0Vy0b4Y20QyG1B2": "job-GZ4q5VQ4X0Vz3jkP95Yb058J",
         "project-GXZg37j4kgGxFZ29fj3f3Yp4": "job-GXby1ZQ4kgGXQK7gyv506Xj9",
-        "project-GXZg0J04BXfPFFZYYFGz42bP": "job-GXbyZ104BXf8G5296g93bvx2"
+        "project-GXZg0J04BXfPFFZYYFGz42bP": "job-GXbyZ104BXf8G5296g93bvx2",
+        "project-GjFx5VQ48q2Bj4BQ5ZgfZJQx": "job-GjGbV4848q2F8P0419V093vJ",
+        "project-GkQv26j4Q5Yzk2VjK9bXgxFb": "job-GkVKff84Q5YzYJPP8VK4v4P6"
     },
     "dias_single_paths": {
         "project-GgXvB984QX3xF6qkPK4Kp5xx": "/output/CEN-240304_1257",

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -295,7 +295,6 @@ class TestCreateFolder(unittest.TestCase):
             assert args['folder'] == '/test_dir'
 
 
-
 @patch('bin.utils.dx_manage.dxpy.find_data_objects')
 @patch(
     'bin.utils.dx_manage.concurrent.futures.ThreadPoolExecutor.submit',
@@ -859,6 +858,52 @@ class TestGetSingleDir(unittest.TestCase):
         )
 
         assert returned_paths == [], 'Missing Dias single dir incorrect'
+
+
+@patch('bin.utils.dx_manage.dxpy.find_data_objects')
+class TestGetMultiqcReport(unittest.TestCase):
+    """
+    Tests for dx_manage.get_multiqc_report
+
+    Function returns a list of file IDs from searching a given
+    project:path for multiQC HTML reports
+    """
+    def test_ids_returned_correctly(self, mock_find):
+        """
+        Test when reports are found that a list of IDs are returned
+        """
+        mock_find.return_value = [
+            {
+                'project': 'project-xxx',
+                'id': 'file-xxx'
+            },
+            {
+                'project': 'project-yyy',
+                'id': 'file-yyy'
+            }
+        ]
+
+        returned_file_ids = dx_manage.get_multiqc_report(
+            single_path='project-xxx:/output/240802'
+        )
+
+        assert sorted(returned_file_ids) == ['file-xxx', 'file-yyy'], (
+            'multiQC report IDs returned incorrect'
+        )
+
+    def test_project_path_split_correct(self, mock_find):
+        """
+        Test that the correct parameters are passed to dxpy.find_data_objects
+        """
+        returned_file_ids = dx_manage.get_multiqc_report(
+            single_path='project-xxx:/output/240802'
+        )
+
+        with self.subTest('correct project'):
+            assert mock_find.call_args[1]['project'] == 'project-xxx'
+
+        with self.subTest('correct folder'):
+            assert mock_find.call_args[1]['folder'] == '/output/240802'
 
 
 @patch('bin.utils.dx_manage.dxpy.bindings.search.find_apps')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -306,10 +306,6 @@ class TestFilterClaritySamplesWithNoReports(unittest.TestCase):
             assert expected_without_reports in stdout
 
 
-
-
-
-
 class TestGroupSamplesByProject(unittest.TestCase):
     """
     Tests for utils.group_samples_by_project
@@ -908,6 +904,20 @@ class TestParseSampleIdentifiers(unittest.TestCase):
                 },
                 "archivalState": "live"
             }
+        },
+        {
+            "project": "project-Gk7bv204fz4YVzb8Yp0BYjG2",
+            "id": "file-GkBypqj4X9G88hfbf7y7bdbdvwlA",
+            "describe": {
+                "id": "file-GkBypqj4X9G88hfbf7y7bdbdvwlA",
+                "name": "333333333-9876R54321-24NGCEN41-9527-F-99347387_HGNC:1234_SNV_1.xlsx",
+                "createdBy": {
+                    "user": "user-1",
+                    "job": "job-GkBy0k04fz4Y4BG6yv38XkzQ",
+                    "executable": "app-Gj6YVp841jVJZZbXV9xXGybk"
+                },
+                "archivalState": "live"
+            }
         }
     ]
 
@@ -930,6 +940,12 @@ class TestParseSampleIdentifiers(unittest.TestCase):
                 "project": "project-Gk7bv204fz4YVzb8Yp0BYjG2",
                 "sample": "222222222-9876R54321-24NGCEN41-9527-F-99347387",
                 "instrument_id": "222222222",
+                "specimen_id": "9876R54321"
+            },
+            {
+                "project": "project-Gk7bv204fz4YVzb8Yp0BYjG2",
+                "sample": "333333333-9876R54321-24NGCEN41-9527-F-99347387",
+                "instrument_id": "333333333",
                 "specimen_id": "9876R54321"
             }
         ]
@@ -980,6 +996,12 @@ class TestParseSampleIdentifiers(unittest.TestCase):
                 "project": "project-Gk7bv204fz4YVzb8Yp0BYjG2",
                 "sample": "222222222-9876R54321-24NGCEN41-9527-F-99347387",
                 "instrument_id": "222222222",
+                "specimen_id": "9876R54321"
+            },
+            {
+                "project": "project-Gk7bv204fz4YVzb8Yp0BYjG2",
+                "sample": "333333333-9876R54321-24NGCEN41-9527-F-99347387",
+                "instrument_id": "333333333",
                 "specimen_id": "9876R54321"
             }
         ]


### PR DESCRIPTION
- add new function `dx_manage.get_multiqc_report` to find multiqc reports to provide as input to batch
- add unit tests for above
- minor fixes for incorrect return types
- update `configs/manually_selected.json` with 2 new CNV call job IDs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/43)
<!-- Reviewable:end -->
