### PR TITLE
yet another unintended feature fix

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,3 @@
+pycodestyle:
+  ignore:
+    - E303  # too many blank lines (2) - this can go away as I like more

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -759,7 +759,8 @@ def main():
     ])
 
     print(
-        f"\nConfirm running reports for all {total_samples} samples in "
+        f"\nConfirm running reports for all {total_samples} samples with "
+        f"{len(sample_data.keys())} dias batch jobs in "
         f"{args.test_project if args.test_project else 'original 002 projects'}"
     )
     while True:

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -348,14 +348,12 @@ def limit_samples(samples, limit=None, start=None, end=None) -> dict:
     # pre-sort sample list by booked in datetime stored against each
     samples = sorted(samples, key=lambda d: d['date'])
 
-    print(samples[0]['date'])
-    print(samples[-1]['date'])
-
     print(
         "\nLimiting samples retained for running reports, currently have "
-        f"{len(samples)} samples from Clarity.\nEarliest booked sample in "
-        f"Clarity export: {samples[0]['date']}\nLatest booked sample in "
-        f"Clarity export: {samples[-1]['date']}\nLimits specified:\n\t"
+        f"{len(samples)} samples from Clarity.\n\nEarliest booked sample in "
+        f"Clarity export: {samples[0]['date'].strftime('%Y-%m-%d')}\n"
+        f"Latest booked sample in Clarity export: "
+        f"{samples[-1]['date'].strftime('%Y-%m-%d')}\nLimits specified:\n\t"
         f"Maximum number samples: {limit}\n\tDate range: "
         f"{start.strftime('%Y-%m-%d')} : {end.strftime('%Y-%m-%d')}"
     )
@@ -381,7 +379,7 @@ def limit_samples(samples, limit=None, start=None, end=None) -> dict:
     if not limited_samples:
         # no samples left in selected date range => exit
         print(
-            "\nWARNING - no samples present in Clarity from the provided "
+            "\nWARNING: no samples present in Clarity from the provided "
             "date range. Exiting now."
         )
         exit(0)

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -345,19 +345,24 @@ def limit_samples(samples, limit=None, start=None, end=None) -> dict:
 
     end = date_str_to_datetime(end)
 
+    # pre-sort sample list by booked in datetime stored against each
+    samples = sorted(samples, key=lambda d: d['date'])
+
+    print(samples[0]['date'])
+    print(samples[-1]['date'])
+
     print(
         "\nLimiting samples retained for running reports, currently have "
-        f"{len(samples)} samples from Clarity.\nLimits "
-        f"specified:\n\tMaximum number samples: {limit}\n\tDate range: "
+        f"{len(samples)} samples from Clarity.\nEarliest booked sample in "
+        f"Clarity export: {samples[0]['date']}\nLatest booked sample in "
+        f"Clarity export: {samples[-1]['date']}\nLimits specified:\n\t"
+        f"Maximum number samples: {limit}\n\tDate range: "
         f"{start.strftime('%Y-%m-%d')} : {end.strftime('%Y-%m-%d')}"
     )
 
     limited_samples = []
     sample_dates = []
     selected_samples = 0
-
-    # pre-sort sample list by booked in datetime stored against each
-    samples = sorted(samples, key=lambda d: d['date'])
 
     for sample in samples:
         if limit:
@@ -372,6 +377,14 @@ def limit_samples(samples, limit=None, start=None, end=None) -> dict:
         limited_samples.append(sample)
         sample_dates.append(sample['date'])
         selected_samples += 1
+
+    if not limited_samples:
+        # no samples left in selected date range => exit
+        print(
+            "\WARNING - no samples present in Clarity from the provided "
+            "date range. Exiting now."
+        )
+        exit(0)
 
     print(
         f"{len(limited_samples)} samples selected. Earliest sample: "

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -381,7 +381,7 @@ def limit_samples(samples, limit=None, start=None, end=None) -> dict:
     if not limited_samples:
         # no samples left in selected date range => exit
         print(
-            "\WARNING - no samples present in Clarity from the provided "
+            "\nWARNING - no samples present in Clarity from the provided "
             "date range. Exiting now."
         )
         exit(0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -889,9 +889,6 @@ class TestLimitSamples(unittest.TestCase):
             assert expected_stdout in self.capsys.readouterr().out
 
 
-
-
-
 class TestParseConfig(unittest.TestCase):
     """
     Tests for utils.parse_config

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -682,6 +682,12 @@ class TestLimitSamples(unittest.TestCase):
         }
     ]
 
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        """Capture stdout to provide it to tests"""
+        self.capsys = capsys
+
+
     def test_integer_limit_works(self):
         """
         Test that limit parameter works as expected, this should take
@@ -857,6 +863,33 @@ class TestLimitSamples(unittest.TestCase):
         assert limited_samples == expected_samples, (
             'incorrect samples retained with integer and date range limits'
         )
+
+
+    def test_no_samples_in_range_zero_exit_code(self):
+        """
+        Test that when we have no Clarity samples in the provided dates
+        that the function cleanly exits with a message to stdout and a
+        zero exit code
+        """
+        with pytest.raises(SystemExit) as zero_exit:
+            utils.limit_samples(
+                samples=self.sample_data,
+                start='290301',
+                end='291201'
+            )
+
+        with self.subTest('correct exit code'):
+            assert zero_exit.value.code == 0
+
+        with self.subTest('correct stdout'):
+            expected_stdout = (
+                'WARNING - no samples present in Clarity from the provided '
+                'date range. Exiting now.'
+            )
+            assert expected_stdout in self.capsys.readouterr().out
+
+
+
 
 
 class TestParseConfig(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -883,7 +883,7 @@ class TestLimitSamples(unittest.TestCase):
 
         with self.subTest('correct stdout'):
             expected_stdout = (
-                'WARNING - no samples present in Clarity from the provided '
+                'WARNING: no samples present in Clarity from the provided '
                 'date range. Exiting now.'
             )
             assert expected_stdout in self.capsys.readouterr().out


### PR DESCRIPTION
- add number of batch jobs to be launched to the confirmation message
- add `.pep8speaks.yml` to silence E303 pep8 warnings from pep8 speaks as I don't care for it
- fix bug in `utils.limit_samples` where having no samples left would raise a TypeError
  - now check for no samples left after limiting, print a warning and cleanly exit
  - added extra unit test to check the above change
- example stdout from limiting with a date range that contains no samples:
```
Limiting samples retained for running reports, currently have 1219 samples from Clarity.

Earliest booked sample in Clarity export: 2023-05-24
Latest booked sample in Clarity export: 2024-04-16
Limits specified:
        Maximum number samples: None
        Date range: 2024-09-09 : 2024-08-08

WARNING: no samples present in Clarity from the provided date range. Exiting now.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/48)
<!-- Reviewable:end -->
