### PR TITLE
unintended feature fixes round 2

### DIFF
--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -141,6 +141,12 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
             f"{datetime.today().strftime('%y%m%d_%H%M')}"
             "_invalid_test_codes.json"
         )
+
+        invalid_test_log = path.abspath(path.join(
+            path.dirname(path.abspath(__file__)),
+            f"../../logs/{invalid_test_log}"
+        ))
+
         with open(invalid_test_log, 'w') as fh:
             json.dump(invalid_sample_tests, fh)
 

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -775,7 +775,7 @@ def main():
         else:
             print("Invalid response, please enter 'y' or 'n'")
 
-    now = datetime.datetime.today().strftime('%y%m%d_%H%M')
+    now = datetime.today().strftime('%y%m%d_%H%M')
     launched_job_log = f"launched_jobs_{now}_log.json"
 
     batch_job_ids = run_all_batch_jobs(args=args, all_sample_data=sample_data)

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -320,7 +320,6 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
     """
     now = datetime.now().strftime("%y%m%d_%H%M")
 
-    create_folder(path=f"/manifests/{now}")
     batch_app_id = get_latest_dias_batch_app()
 
     launched_jobs = []
@@ -336,6 +335,11 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
             sample_data=project_data['samples'],
             project_name=project_data['project_name'],
             now=now
+        )
+
+        create_folder(
+            project=batch_project,
+            path=f"/manifests/{now}"
         )
 
         manifest_id = upload_manifest(

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -376,14 +376,6 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
 
         launched_jobs.append(batch_id)
 
-        job_id_log = path.join(
-            path.dirname(path.abspath(__file__)),
-            f"../logs/launched_batch_jobs_{now}.log"
-        )
-
-        with open(job_id_log, "a") as fh:
-            fh.write(f"{batch_id}\n")
-
     print(f"Launched {len(launched_jobs)} Dias batch jobs")
 
     return launched_jobs

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -63,7 +63,7 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
         "project-xxx": {
             "project_name": "002_240401_A01295_0334_XXYNSHDBDR",
             "cnv_call_job_id": "job-xxx",
-            "dias_single_path": "project-xxx:/output/CEN_240401_1105",
+            "dias_single": "project-xxx:/output/CEN_240401_1105",
             "samples": [
                 {
                     "sample": "123456-23251R0047",
@@ -355,7 +355,7 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
             project=batch_project,
             batch_app_id=batch_app_id,
             cnv_job=project_data['cnv_call_job_id'],
-            single_path=project_data['dias_single_path'],
+            single_path=project_data['dias_single'],
             manifest=manifest_id,
             name=name,
             batch_inputs=args.batch_inputs,

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -277,7 +277,7 @@ def write_manifest(project_name, sample_data, now) -> List[dict]:
     str
         file name of manifest generated
     """
-    print(f"Generating manifest data for {len(sample_data)} samples")
+    print(f"\nGenerating manifest data for {len(sample_data)} samples")
 
     manifest = f"{project_name}-{now}_re_run.manifest"
     count = 0
@@ -771,7 +771,7 @@ def main():
         confirm = input('Run jobs? ')
 
         if confirm.lower() in ['y', 'yes']:
-            print("Beginning launching jobs...")
+            print("\nBeginning launching jobs...")
             break
         elif confirm.lower() in ['n', 'no']:
             print("Stopping now.")

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -372,7 +372,7 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
 
         job_id_log = path.join(
             path.dirname(path.abspath(__file__)),
-            f"../../logs/launched_batch_jobs_{now}.log"
+            f"../logs/launched_batch_jobs_{now}.log"
         )
 
         with open(job_id_log, "a") as fh:

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -10,6 +10,7 @@ from typing import List, Union
 
 import dxpy
 import pandas as pd
+from tqdm import tqdm
 
 from .utils import call_in_parallel
 
@@ -389,7 +390,7 @@ def get_xlsx_reports(all_samples, projects) -> list:
 
     all_reports = []
 
-    for project in projects:
+    for project in tqdm(projects, ncols=100):
         project_reports = []
 
         project_reports = find_in_parallel(
@@ -399,8 +400,6 @@ def get_xlsx_reports(all_samples, projects) -> list:
             suffix='.*xlsx'
         )
         all_reports.extend(project_reports)
-
-        print(f"Found {len(project_reports)} reports in project {project}")
 
     # filter out any xlsx files found that look to also have a run ID
     # in the name => output from eggd_artemis for a single sample

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -158,16 +158,20 @@ def download_single_file(dxid, project, path) -> None:
     )
 
 
-def create_folder(path) -> None:
+def create_folder(project, path) -> None:
     """
     Create folder for storing manifests
 
     Parameters
     ----------
+    project : str
+        project to create folder in
     path : str
         folder to create
     """
-    dxpy.bindings.dxproject.DXProject().new_folder(folder=path, parents=True)
+    dxpy.bindings.dxproject.DXProject(dxid=project).new_folder(
+        folder=path, parents=True
+    )
 
 
 def find_in_parallel(project, items, prefix='', suffix='') -> list:

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -576,8 +576,6 @@ def run_batch(
         app_input=app_input, project=project, name=name
     )
 
-    print(f"Launched dias batch job {job.id} in {project}")
-
     return job.id
 
 

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -648,7 +648,7 @@ def validate_test_codes(all_sample_data, genepanels) -> None:
         print(
             "\nWARNING: one or more samples with invalid test code(s)\n"
             "These sample-tests will be excluded for reanalysis:\n\n\t"
-            f"{printable_invalid}"
+            f"{printable_invalid}\n"
         )
     else:
         print("All sample test codes valid!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest-mock==3.11.1
 pytest-random-order==1.1.1
 pytest-repeat==0.9.3
 pytest-subtests==0.11.0
+tqdm==4.66.5

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -321,7 +321,7 @@ class TestCreateFolder(unittest.TestCase):
         """
         Test that dxpy.bindings.dxproject.DXProject.new_folder is called
         """
-        dx_manage.create_folder(path='/test_dir')
+        dx_manage.create_folder(project='project-xxx', path='/test_dir')
 
         with self.subTest('DXProject.new_folder called'):
             assert mock_project.return_value.new_folder.call_count == 1


### PR DESCRIPTION
Mostly tiny fixes to actually get to a state of being able to launch jobs:

- fix breaking on `datetime` for log naming
- fix dias single path key selection
- minor formatting for easier reading in stdout
- ensure invalid test code log file goes to `logs/`
- add `tqdm` for prettier stdout with a progress bar on searching all 002 projects (limits the massive amount of stdout)
![image](https://github.com/user-attachments/assets/ddfaf6a1-8a35-49a8-86f6-4a9c56e9a2bf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/49)
<!-- Reviewable:end -->
