### PR TITLE
check job states and handle fails in downloading

### DIFF
--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -652,6 +652,11 @@ def download_all_reports(log_file, output_path) -> None:
         log file to read job IDs from
     output_path : str
         path of where to download files to
+
+    Raises
+    ------
+    SystemExit
+        Will exit with zero exit code on any jobs being still in progress
     """
     job_ids = read_from_log(log_file=log_file)
     batch_job_ids = job_ids.get('dias_batch')

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -42,8 +42,8 @@ def check_archival_state(project, sample_data) -> Union[list, list, list]:
     # and Artemis
     sample_file_patterns = [
         '_segments.vcf$',
-        '_copy_ratios.gcnv.bed$',
-        '_copy_ratios.gcnv.bed.tbi$',
+        '_copy_ratios.gcnv.bed.gz$',
+        '_copy_ratios.gcnv.bed.gz.tbi$',
         '_markdup.per-base.bed.gz$',
         '_markdup_recalibrated_Haplotyper.vcf.gz$',
         '_markdup.reference_build.txt$',

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -126,7 +126,9 @@ def check_job_state(jobs) -> dict:
     )
 
     if all_job_states['failed']:
-        failed_job_projects = set([x['project'] for x in all_job_states['failed']])
+        failed_job_projects = sorted(set([
+            x['project'] for x in all_job_states['failed']
+        ]))
 
         base_url = (
             "https://platform.dnanexus.com/panx/projects/"
@@ -139,10 +141,10 @@ def check_job_state(jobs) -> dict:
         ])
 
         print(
-            f"\nWARNING: one or more jobs in a failed / terminated state.\n\n"
-            f"Projects with failed jobs:\n\t{failed_urls}"
+            f"\nWARNING: {len(all_job_states['failed'])} jobs in a failed / "
+            f"terminated state.\n\nProjects with failed jobs:\n\t{failed_urls}"
         )
-  $
+
     return all_job_states
 
 

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -3,8 +3,6 @@ Functions relating to managing data objects an queries in DNAnexus
 """
 import concurrent
 from datetime import datetime
-from itertools import groupby
-from operator import itemgetter
 import os
 from pathlib import Path
 import re


### PR DESCRIPTION
- added new function `dx_manage.check_job_states`
  - used to check state of jobs before downloading, any failed/terminated will print a warning to stdout but not raise an error
  - any in progress jobs will cause a warning to print and for it to exit to not download partial outputs
  - add unit tests for new function
- changes to download logic to handle failed / terminated runs and missing outputs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/50)
<!-- Reviewable:end -->
