### PR TITLE
add unit tests for utils.filter_reports_with_variants

### DIFF
--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -436,7 +436,8 @@ def filter_reports_with_variants(reports, report_field) -> list:
     # to just download both the xlsx and coverage reports for those
     workflows_w_variants = [
         x for x in reports
-        if x['output'].get(report_field).get('$dnanexus_link') in xlsx_w_variants
+        if x['output'].get(report_field, {}).get(
+            '$dnanexus_link') in xlsx_w_variants
     ]
 
     # get the file IDs of our output files to download


### PR DESCRIPTION
- add bonus unit tests for `utils.filter_reports_with_variants` added in #50 to get back to 100% coverage on utils.py
- fix issue in selecting report field that isn't present by providing default to `.get()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/51)
<!-- Reviewable:end -->
