### PR TITLE
Fixes for downloading files

### DIFF
--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -750,6 +750,7 @@ def download_all_reports(log_file, output_path) -> None:
         call_in_parallel(
             download_single_file,
             snv_ids + cnv_ids + artemis_links_ids + multiqc_ids,
+            ignore_missing=True,
             project=project_id,
             path=project_path
         )

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -689,8 +689,14 @@ def download_all_reports(log_file, output_path) -> None:
 
     project_job_details = group_dx_objects_by_project(job_details)
 
+    count = 0
+
     for project_id, project_data in project_job_details.items():
-        print(f"\nDownloading files for {project_data['project_name']}")
+        count += 1
+        print(
+            f"\n[{count}/{len(project_job_details.keys())}] Downloading "
+            f"files for {project_data['project_name']} ({project_id})\n"
+        )
 
         snv_report_jobs = [
             x for x in project_data['items'] if x['id'].startswith('analysis-')

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -701,7 +701,7 @@ def download_all_reports(log_file, output_path) -> None:
             and 'dias_cnvreports' in x['executableName']
         ]
         artemis_jobs = [
-            x for x in project_data['items'] if x['id'].startswith('job-')
+            x for x in project_data['items'] if x['name'] == 'eggd_artemis'
         ]
 
         # get just snv and cnv reports (plus coverage reports) for reports
@@ -719,6 +719,13 @@ def download_all_reports(log_file, output_path) -> None:
         artemis_links_ids = multiqc_ids = []
 
         if artemis_jobs:
+            # for job in artemis_jobs:
+            #     print(job)
+
+            # for job in artemis_jobs:
+            #     print(job['id'])
+            #     print(job['output'])
+
             artemis_links_ids = [
                 x['output']['url_file']['$dnanexus_link'] for x in artemis_jobs
                 if x['output']

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -719,13 +719,6 @@ def download_all_reports(log_file, output_path) -> None:
         artemis_links_ids = multiqc_ids = []
 
         if artemis_jobs:
-            # for job in artemis_jobs:
-            #     print(job)
-
-            # for job in artemis_jobs:
-            #     print(job['id'])
-            #     print(job['output'])
-
             artemis_links_ids = [
                 x['output']['url_file']['$dnanexus_link'] for x in artemis_jobs
                 if x['output']

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -670,7 +670,8 @@ def download_all_reports(log_file, output_path) -> None:
 
     print(
         f"{len(launched_job_ids)} jobs from {len(batch_job_ids)} dias batch "
-        f"jobs to download output reports from...\n"
+        f"jobs to download output reports from. Checking details of all "
+        "launched jobs...\n"
     )
 
     job_details = call_in_parallel(dxpy.describe, launched_job_ids)

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -220,7 +220,6 @@ def download_single_file(dxid, project, path) -> None:
     path : str
         path to download file to
     """
-    # try:
     dxpy.bindings.dxfile_functions.download_dxfile(
         dxid,
         os.path.join(path, dxpy.describe(dxid).get('name')),

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -400,7 +400,7 @@ def get_launched_workflow_ids(batch_ids) -> Union[list, list]:
 
     # the only single jobs *should* be eggd_artemis here since we aren't
     # running CNV calling, split this from the reports jobs
-    artemis_jobs = [x for x in report_jobs if x.get('name') == 'eggd_artemis']
+    artemis_jobs = [x for x in report_jobs if x.startswith('job-')]
     report_jobs = [x for x in report_jobs if x.startswith('analysis-')]
 
     return artemis_jobs, report_jobs

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -400,7 +400,7 @@ def get_launched_workflow_ids(batch_ids) -> Union[list, list]:
 
     # the only single jobs *should* be eggd_artemis here since we aren't
     # running CNV calling, split this from the reports jobs
-    artemis_jobs = [x for x in report_jobs if x['name'] == 'eggd_artemis']
+    artemis_jobs = [x for x in report_jobs if x.get('name') == 'eggd_artemis']
     report_jobs = [x for x in report_jobs if x.startswith('analysis-')]
 
     return artemis_jobs, report_jobs

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -220,19 +220,12 @@ def download_single_file(dxid, project, path) -> None:
     path : str
         path to download file to
     """
-    try:
-        dxpy.bindings.dxfile_functions.download_dxfile(
-            dxid,
-            os.path.join(path, dxpy.describe(dxid).get('name')),
-            project=project
-        )
-    except dxpy.exceptions.ResourceNotFound:
-        # exception raised when file has been deleted, let anything else
-        # continue to raise and exit
-        print(
-            f'WARNING: {dxid} could not be found (assumed deleted)m skipping '
-            'downloading file'
-        )
+    # try:
+    dxpy.bindings.dxfile_functions.download_dxfile(
+        dxid,
+        os.path.join(path, dxpy.describe(dxid).get('name')),
+        project=project
+    )
 
 
 def create_folder(project, path) -> None:
@@ -407,7 +400,7 @@ def get_launched_workflow_ids(batch_ids) -> Union[list, list]:
 
     # the only single jobs *should* be eggd_artemis here since we aren't
     # running CNV calling, split this from the reports jobs
-    artemis_jobs = [x for x in report_jobs if x.startswith('job-')]
+    artemis_jobs = [x for x in report_jobs if x['name'] == 'eggd_artemis']
     report_jobs = [x for x in report_jobs if x.startswith('analysis-')]
 
     return artemis_jobs, report_jobs

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -220,11 +220,19 @@ def download_single_file(dxid, project, path) -> None:
     path : str
         path to download file to
     """
-    dxpy.bindings.dxfile_functions.download_dxfile(
-        dxid,
-        os.path.join(path, dxpy.describe(dxid).get('name')),
-        project=project
-    )
+    try:
+        dxpy.bindings.dxfile_functions.download_dxfile(
+            dxid,
+            os.path.join(path, dxpy.describe(dxid).get('name')),
+            project=project
+        )
+    except dxpy.exceptions.ResourceNotFound:
+        # exception raised when file has been deleted, let anything else
+        # continue to raise and exit
+        print(
+            f'WARNING: {dxid} could not be found (assumed deleted)m skipping '
+            'downloading file'
+        )
 
 
 def create_folder(project, path) -> None:

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -432,7 +432,7 @@ def filter_reports_with_variants(reports, report_field) -> list:
     # variants by using the 'included' key in the details metadata,
     xlsx_report_ids = [
         job.get('output', {}).get(report_field, {}).get('$dnanexus_link')
-        for job in reports if job.get('output')
+        for job in reports if job.get('output', {}).get(report_field, {})
     ]
 
     xlsx_details = call_in_parallel(

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -13,7 +13,7 @@ import dxpy
 import pandas as pd
 
 
-def call_in_parallel(func, items, **kwargs) -> list:
+def call_in_parallel(func, items, ignore_missing=True, **kwargs) -> list:
     """
     Calls the given function in parallel using concurrent.futures on
     the given set of items (i.e for calling dxpy.describe() on multiple
@@ -28,6 +28,10 @@ def call_in_parallel(func, items, **kwargs) -> list:
         function to call on each item
     items : list
         list of items to call function on
+    ignore_missing : bool
+        controls if to just print a warning instead of raising an
+        exception on a dxpy.exceptions.ResourceNotFound being raised.
+        This is most likely from a file that has been deleted.
 
     Returns
     -------
@@ -46,9 +50,21 @@ def call_in_parallel(func, items, **kwargs) -> list:
             try:
                 results.append(future.result())
             except Exception as exc:
-                # catch any errors that might get raised during querying
+                if (
+                    ignore_missing and
+                    isinstance(exc, dxpy.exceptions.ResourceNotFound)
+                ):
+                    # dx object does not exist and specifying to skip,
+                    # just print warning and continue'
+                    print(
+                        f'WARNING: {concurrent_jobs[future]} could not be '
+                        'found, skipping to not raise an exception'
+                    )
+                    continue
+
+                # catch any other errors that might get raised during querying
                 print(
-                    f"Error getting data for {concurrent_jobs[future]}: {exc}"
+                    f"\nError getting data for {concurrent_jobs[future]}: {exc}"
                 )
                 raise exc
 

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -13,7 +13,7 @@ import dxpy
 import pandas as pd
 
 
-def call_in_parallel(func, items, ignore_missing=True, **kwargs) -> list:
+def call_in_parallel(func, items, ignore_missing=False, **kwargs) -> list:
     """
     Calls the given function in parallel using concurrent.futures on
     the given set of items (i.e for calling dxpy.describe() on multiple
@@ -438,6 +438,7 @@ def filter_reports_with_variants(reports, report_field) -> list:
     xlsx_details = call_in_parallel(
         dxpy.describe,
         xlsx_report_ids,
+        ignore_missing=True,
         fields={'details'},
         default_fields=True
     )

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -31,7 +31,8 @@ def call_in_parallel(func, items, ignore_missing=True, **kwargs) -> list:
     ignore_missing : bool
         controls if to just print a warning instead of raising an
         exception on a dxpy.exceptions.ResourceNotFound being raised.
-        This is most likely from a file that has been deleted.
+        This is most likely from a file that has been deleted and we are
+        just going to default to ignoring these
 
     Returns
     -------


### PR DESCRIPTION
various small fixes for downloading files from attempting to download >30 recent run reports:
- switch to checking for eggd_artemis jobs from the job name instead of relying on `job-xxx`
- add `ignore_missing` optional param to `utils.call_in_parallel`
  - allows for explicitly ignoring `dxpy.exceptions.ResourceNotFound` from being raised on files that do not exist (i.e have been deleted)
  - this is just being enabled during downloading to skip any files that are output and then deleted
- extra unit tests for changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/52)
<!-- Reviewable:end -->
