### PR TITLE
Fix passing multiQC report ID as batch input

### DIFF
--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -365,6 +365,7 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
             cnv_job=project_data['cnv_call_job_id'],
             single_path=project_data['dias_single'],
             manifest=manifest_id,
+            multiqc_report_id=project_data['multiqc'],
             name=name,
             batch_inputs=args.batch_inputs,
             assay=args.assay,

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -546,7 +546,7 @@ def parse_args() -> argparse.Namespace:
     )
     reanalysis_parser.add_argument(
         "--monitor",
-        type=bool,
+        action='store_true',
         default=True,
         help=(
             "Controls if to monitor and report on state of launched "

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -634,7 +634,7 @@ def run_batch(
         "snv_reports": True,
         "artemis": True,
         "manifest_files": [{"$dnanexus_link": manifest}],
-        "multiqc_report": [{"$dnanexus_link": multiqc_report_id}],
+        "multiqc_report": {"$dnanexus_link": multiqc_report_id},
         "single_output_dir": single_path,
         "assay": assay,
         "testing": terminate,

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -588,6 +588,7 @@ def run_batch(
     cnv_job,
     single_path,
     manifest,
+    multiqc_report_id,
     name,
     batch_inputs,
     assay,
@@ -608,6 +609,8 @@ def run_batch(
         path to Dias single output
     manifest : str
         file ID of uploaded manifest
+    multiqc_report_id : str
+        file ID of multiQC report to pass to eggd_artemis
     name : str
         name to use for batch job
     batch_inputs : dict
@@ -631,6 +634,7 @@ def run_batch(
         "snv_reports": True,
         "artemis": True,
         "manifest_files": [{"$dnanexus_link": manifest}],
+        "multiqc_report": multiqc_report_id,
         "single_output_dir": single_path,
         "assay": assay,
         "testing": terminate,

--- a/bin/utils/dx_manage.py
+++ b/bin/utils/dx_manage.py
@@ -634,7 +634,7 @@ def run_batch(
         "snv_reports": True,
         "artemis": True,
         "manifest_files": [{"$dnanexus_link": manifest}],
-        "multiqc_report": multiqc_report_id,
+        "multiqc_report": [{"$dnanexus_link": multiqc_report_id}],
         "single_output_dir": single_path,
         "assay": assay,
         "testing": terminate,

--- a/tests/test_dx_manage.py
+++ b/tests/test_dx_manage.py
@@ -1131,6 +1131,7 @@ class TestRunBatch(unittest.TestCase):
             'batch_app_id': 'app-xxx',
             'single_path': '/output',
             'manifest': 'file-xxx',
+            'multiqc_report_id': 'file-yyy',
             'name': 'dias_batch',
             'batch_inputs': {},
             'assay': 'test',
@@ -1162,6 +1163,7 @@ class TestRunBatch(unittest.TestCase):
             'batch_app_id': 'app-xxx',
             'single_path': '/output',
             'manifest': 'file-xxx',
+            'multiqc_report_id': 'file-yyy',
             'name': 'dias_batch',
             'assay': 'test',
             'terminate': False


### PR DESCRIPTION
- fixes missed passing of multiQC report ID to dias batch as input
- switch `--monitor` from boolean input to a flag for easier running

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/53)
<!-- Reviewable:end -->
