### PR TITLE
Docker time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# ignore everything except for the required files to run, stops any erroneous config / output files
+# being bundled in the built image
+/**
+!/bin
+!/configs
+!/tests
+!/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ COPY . /reanalysis
 
 RUN mkdir -p output/ logs/
 
-# display help if no args sepcified
+# display help if no args specified
 CMD bin/run_reports.py --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+WORKDIR /reanalysis
+
+COPY . /reanalysis
+
+RUN mkdir -p output/ logs/
+
+# display help if no args sepcified
+CMD bin/run_reports.py --help

--- a/README.md
+++ b/README.md
@@ -140,17 +140,29 @@ job-Gp3vXPQ4BgGVFxJ76VG89ZbG    done
 job-GpFk6pj4z9pgpy7pKGx44KP3    done
 ```
 
-* check the state of dias_reports jobs:
+* check the state of all jobs launched by the dias batch jobs in the log file:
 ```
-$ jq -r '.dias_reports[]' launched_jobs_240729_1035_log.json | xargs -P16 -I{} sh -c "dx describe --json {} | jq -r '[.id,.state] | @tsv'"
-analysis-GpP4gy049kjfgJ290YPG803B       done
-analysis-GpP4gxQ49kjfgJ290YPG8030       done
-analysis-GpP4gx849kjX9bjk9XjF6K8q       done
-analysis-GpP4gy849kjxGY2YGy7117B2       done
-```
-
-* check the state of eggd_artemis jobs:
-```
-$ jq -r '.eggd_artemis[]' launched_jobs_240729_1035_log.json | xargs -P16 -I{} sh -c "dx describe --json {} | jq -r '[.id,.state] | @tsv'"
-job-GpFp6v84z9pYz690YgkP7JJX    done
+$ xargs -P32 -n1 -I{} bash -c 'dx describe --json {} | jq -r "[.id,.state] | @tsv"' <<< $(jq -r '.dias_batch[]' launched_jobs_240808_1311_log.json | xargs -P32 -I{} dx describe --json {} | jq -r '.output.launched_jobs' | sed 's/,/\n/g') | sort -k2
+analysis-GppFKxj45jXXZQJYP5y39YqV       done
+analysis-GppFKy845jXyJpJXPzq06YYz       done
+analysis-GppFKyQ45jXQJQyy3KZKZ0QP       done
+analysis-GppFKz045jXyJpJXPzq06YZP       done
+analysis-GppFP0045jXYZPg13B3B0fZz       done
+analysis-GppFP0845jXy2qx9qv109FY7       done
+analysis-GppFP0j45jXyJpJXPzq06Yb6       done
+analysis-GppFP1045jXbyF1K93PJKkQG       done
+analysis-GppFP1045jXx3ZFz0389KXq2       done
+analysis-GppFP1845jXzYP89kqx0gXbg       done
+analysis-GppFP1j45jXVbpQf5G3BZ4fF       done
+analysis-GppFP2045jXy6XB5ZGF168jG       done
+analysis-GppFP2Q45jXVbpQf5G3BZ4fg       done
+analysis-GppFP3045jXzYP89kqx0gXf9       done
+analysis-GppFP3j45jXV62JYkGg3j03J       done
+analysis-GppFP4845jXbyF1K93PJKkVY       done
+analysis-GppFP4Q45jXzYP89kqx0gXkP       done
+analysis-GppFP5045jXV62JYkGg3j03z       done
+analysis-GppFP5845jXbyF1K93PJKkX6       done
+analysis-GppFP5j45jXzYP89kqx0gXkv       done
+job-GppFP1Q45jXXZQJYP5y39Yvj    failed
+job-GppFP6045jXgg95vvYkJqGJ5    failed
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Reanalysis inputs:
 * `--monitor` (optional): Controls if to monitor and report on state of launched dias batch jobs
 
 
-
 Download inputs:
 * `--job_log`: json log file output from running reanalysis
 * `--path`: parent directory in which to download sub directories per run of output reports
@@ -121,6 +120,8 @@ The log file is structured as follows:
 ```
 
 For any samples with invalid test code(s), these will print a warning to stdout during running and also be written to a JSON log file to review after (named as `{yymmdd_hhmm}_invalid_test_codes.json`).
+
+Both files will always be output to the `logs/` directory.
 
 ### Example useful commands to query the log file:
 

--- a/README.md
+++ b/README.md
@@ -40,18 +40,24 @@ docker built -t <image_name>:<image_tag>
 
 Running from the built Docker image requires mounting both the `log/` directory and clarity export file for reanalysis, and `output/` directory for downloading output reports, from the container to the host. This is so that when the reanalysis / download completes the log / output files are available outside of the container.
 
+For running reanalysis, it requires confirming if to run all jobs from a user prompt. Therefore this requires first opening a shell interactively in the container, then running the reanalysis command to be able to confirm launching jobs (see example below). Once reanalysis has been launched the container may be exited by simply running `exit`. This is not required for downloading as this has no user prompt.
+
 In addition, access to DNAnexus is required. One way to achieve this is to export the current dx security context as environment variables into the Docker container. This can be done with the following line: `--env-file <(dx env --bash | sed -e "s/export//g" -e "s/'//g")`. This gets the current set security context from the host using `dx env` and formats it as required for passing as an environment 'file' for Docker.
 
 Example command for running reanalysis:
 ```
-docker run \
+# get interactive shell in the container
+$ docker run \
     --env-file <(dx env --bash | sed -e "s/export//g" -e "s/'//g") \
     -v $(pwd)/<clarity_export_xlsx>:/reanalysis/clarity_export.xlsx \
     -v $(pwd):/reanalysis/logs \
-    <image_name>:<image_tag> python3 bin/run_reports.py reanalysis \
-        --clarity_export clarity_export.xlsx \
-        --assay CEN \
-        --monitor
+    <image_name>:<image_tag>
+
+# run reanalysis as would be done locally
+python3 bin/run_reports.py reanalysis \
+    --clarity_export clarity_export.xlsx \
+    --assay CEN \
+    --monitor
 ```
 * the working directory in the image is set to `/reanalysis` which contains `bin/` and `logs/` etc
 * the clarity export xlsx file `<clarity_export.xlsx>` needs mounting into the container

--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ docker built -t <image_name>:<image_tag>
 
 Running from the built Docker image requires mounting both the `log/` directory and clarity export file for reanalysis, and `output/` directory for downloading output reports, from the container to the host. This is so that when the reanalysis / download completes the log / output files are available outside of the container.
 
+In addition, access to DNAnexus is required. One way to achieve this is to export the current dx security context as environment variables into the Docker container. This can be done with the following line: `--env-file <(dx env --bash | sed -e "s/export//g" -e "s/'//g")`. This gets the current set security context from the host using `dx env` and formats it as required for passing as an environment 'file' for Docker.
+
 Example command for running reanalysis:
 ```
 docker run \
+    --env-file <(dx env --bash | sed -e "s/export//g" -e "s/'//g") \
     -v $(pwd)/<clarity_export_xlsx>:/reanalysis/clarity_export.xlsx \
     -v $(pwd):/reanalysis/logs \
-    <image_name>:<image_tag> bin/run_reports.py reanalysis \
+    <image_name>:<image_tag> python3 bin/run_reports.py reanalysis \
         --clarity_export clarity_export.xlsx \
         --assay CEN \
         --monitor
@@ -58,9 +61,10 @@ docker run \
 Example command for downloading outputs once jobs complete:
 ```
 docker run \
+    --env-file <(dx env --bash | sed -e "s/export//g" -e "s/'//g")
     -v $(pwd):/reanalysis/logs \
     -v <local_output_path>:/reanalysis/output
-    <image_name>:<image_tag> bin/run_reports.py download \
+    <image_name>:<image_tag> python3 bin/run_reports.py download \
         --job_log logs/<log_file_from_reanalysis> \
         --path output/
 ```
@@ -83,6 +87,7 @@ Reanalysis inputs:
 * `--test_project` (optional): DNAnexus project ID in which to launch dias batch, if not specified will launch in original 002 projects
 * `--terminate` (optional): Controls if to terminate all analysis jobs dias batch launched
 * `--monitor` (optional): Controls if to monitor and report on state of launched dias batch jobs
+
 
 
 Download inputs:

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -147,7 +147,7 @@ def configure_inputs(clarity_data, assay, limit, start_date, end_date, unarchive
 
         invalid_test_log = path.abspath(path.join(
             path.dirname(path.abspath(__file__)),
-            f"../../logs/{invalid_test_log}"
+            f"../logs/{invalid_test_log}"
         ))
 
         with open(invalid_test_log, 'w') as fh:

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -548,7 +548,7 @@ def parse_args() -> argparse.Namespace:
             args = verify_batch_inputs_argument(args)
 
     input_str = '\n\t'.join(f"{k} : {v}" for k, v in args.__dict__.items())
-    print(f"Specified arguments:\n\t{input_str}\n")
+    print(f"\nSpecified arguments:\n\t{input_str}\n")
 
     return args
 


### PR DESCRIPTION
- adds a Dockerfile and required changes for running in Docker
- updated readme with Docker details
- update readme with example command to check state of all analysis jobs launched by the dias batch jobs
- fix to ensure the invalid test code log file always goes to `logs/`
- testing example reanalysis command from the readme that it can run:
```
$ docker run \
--env-file <(dx env --bash | sed -e "s/export//g" -e "s/'//g") \
-v $(pwd)/clarity_240417_01.xlsx:/reanalysis/clarity_export.xlsx \
-v $(pwd):/reanalysis/logs  bulk_reanalysis:1.0.0 \
python3 bin/run_reports.py reanalysis --clarity_export clarity_export.xlsx --assay CEN

Specified arguments:
        mode : reanalysis
        assay : CEN
        clarity_export : clarity_export.xlsx
        clarity_connect : False
        config : None
        batch_inputs : None
        limit : None
        start_date : None
        end_date : None
        unarchive : None
        test_project : None
        terminate : False
        monitor : True

Found 140 projects for CEN
Searching 140 projects for samples
 14%|████████▊                                                     | 20/140 [00:08<00:40,  2.99it/s]

...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/58)
<!-- Reviewable:end -->
