### PR TITLE
Di 1105 cnv code fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Reanalysis inputs:
 * `--test_project` (optional): DNAnexus project ID in which to launch dias batch, if not specified will launch in original 002 projects
 * `--terminate` (optional): Controls if to terminate all analysis jobs dias batch launched
 * `--monitor` (optional): Controls if to monitor and report on state of launched dias batch jobs
+* `--strip_test_codes` (optional): DNAnexus file ID of file containing test codes to be ignored and not added to the manifest, if present in clarity extract.
 
 
 Download inputs:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Reanalysis inputs:
 * `--test_project` (optional): DNAnexus project ID in which to launch dias batch, if not specified will launch in original 002 projects
 * `--terminate` (optional): Controls if to terminate all analysis jobs dias batch launched
 * `--monitor` (optional): Controls if to monitor and report on state of launched dias batch jobs
-* `--strip_test_codes` (optional): DNAnexus file ID of file containing test codes to be ignored and not added to the manifest, if present in clarity extract.
+* `--ignore_test_codes` (optional): DNAnexus file ID of file containing test codes to be ignored and not added to the manifest, if present in clarity extract. Should be in the format `project-123456:file-123456`
 
 
 Download inputs:

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -8,7 +8,7 @@ import argparse
 from collections import Counter, defaultdict
 from datetime import datetime
 import json
-from os import makedirs, path
+from os import makedirs, path, remove
 from time import sleep
 from typing import List
 
@@ -309,10 +309,22 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
         else:
             batch_project = project
 
+        if args.strip_test_codes:
+            dxpy.bindings.dxfile_functions.download_dxfile(
+                args.strip_test_codes,
+                "codes.txt"
+            )
+            with open("codes.txt") as f:
+                codes_to_strip = f.readlines()
+            remove("codes.txt")
+        else:
+            codes_to_strip = []
+
         manifest = write_manifest(
             sample_data=project_data['samples'],
             project_name=project_data['project_name'],
-            now=now
+            now=now,
+            ignore_codes=codes_to_strip
         )
 
         create_folder(
@@ -521,6 +533,15 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Controls if to monitor and report on state of launched "
             "dias batch jobs"
+        ),
+    )
+    reanalysis_parser.add_argument(
+        "--strip_test_codes",
+        type=str,
+        help=(
+            "DNAnexus file ID of file containing test codes to ignore and not "
+            "add to the manifest. Each line of the file should contain a test "
+            "code."
         ),
     )
 

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -309,8 +309,8 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
         else:
             batch_project = project
 
-        if args.strip_test_codes:
-            codes_project, codes_file = args.strip_test_codes.split(':')
+        if args.ignore_test_codes:
+            codes_project, codes_file = args.ignore_test_codes.split(':')
             dxpy.bindings.dxfile_functions.download_dxfile(
                 codes_file,
                 "codes.txt",

--- a/bin/run_reports.py
+++ b/bin/run_reports.py
@@ -310,12 +310,14 @@ def run_all_batch_jobs(args, all_sample_data) -> list:
             batch_project = project
 
         if args.strip_test_codes:
+            codes_project, codes_file = args.strip_test_codes.split(':')
             dxpy.bindings.dxfile_functions.download_dxfile(
-                args.strip_test_codes,
-                "codes.txt"
+                codes_file,
+                "codes.txt",
+                project=codes_project
             )
             with open("codes.txt") as f:
-                codes_to_strip = f.readlines()
+                codes_to_strip = f.read().splitlines()
             remove("codes.txt")
         else:
             codes_to_strip = []
@@ -536,12 +538,12 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     reanalysis_parser.add_argument(
-        "--strip_test_codes",
+        "--ignore_test_codes",
         type=str,
         help=(
             "DNAnexus file ID of file containing test codes to ignore and not "
             "add to the manifest. Each line of the file should contain a test "
-            "code."
+            "code. Should be in the format project-123456:file-123456"
         ),
     )
 

--- a/bin/utils/utils.py
+++ b/bin/utils/utils.py
@@ -739,7 +739,7 @@ def validate_test_codes(all_sample_data, genepanels) -> None:
     return valid, invalid
 
 
-def write_manifest(project_name, sample_data, now) -> List[dict]:
+def write_manifest(project_name, sample_data, now, ignore_codes) -> List[dict]:
     """
     Write Epic manifest file of all samples for given project
 
@@ -751,6 +751,8 @@ def write_manifest(project_name, sample_data, now) -> List[dict]:
         list of dicts of sample data (IDs and test code(s))
     now : str
         current datetime for naming
+    ignore_codes : list
+        list of test codes to ignore and not add to the manifest
 
     Returns
     -------
@@ -769,7 +771,8 @@ def write_manifest(project_name, sample_data, now) -> List[dict]:
         )
 
         for sample in sample_data:
-            for code in sample['codes']:
+            codes = [x for x in sample['codes'] if x not in ignore_codes]
+            for code in codes:
                 fh.write(
                     f"{sample['instrument_id']};{sample['specimen_id']}"
                     f";;;{code}\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1732,6 +1732,7 @@ class TestWriteManifest(unittest.TestCase):
                 'specimen_id': '222R2222',
                 'codes': [
                     'R123.1',
+                    'R123.2',
                     'R456.2'
                 ]
             },
@@ -1744,6 +1745,8 @@ class TestWriteManifest(unittest.TestCase):
                 ]
             }
         ]
+
+        ignore_codes = ["R123.2"]
 
         expected_contents = [
             "batch\n",
@@ -1760,7 +1763,8 @@ class TestWriteManifest(unittest.TestCase):
         manifest = utils.write_manifest(
             project_name='test',
             sample_data=sample_data,
-            now='240813'
+            now='240813',
+            ignore_codes=ignore_codes
         )
 
         with open(manifest, 'r') as fh:


### PR DESCRIPTION
Tested with
```
python3 dias_reports_bulk_reanalysis/bin/run_reports.py reanalysis --assay=CEN \
--clarity_export=Downloads/clarity_240417_01.xlsx \
--test_project=project-Gq1f4q84vzJZX0YQPv88P5X0 \
--ignore_test_codes=project-Fkb6Gkj433GVVvj73J7x8KbV:file-GXGx8q0433GgKqx52Jqz1p47 \
--limit=1
```
Which launched dias reports for the one sample in the clarity extract which has both .1 and .2 test codes
![image](https://github.com/user-attachments/assets/07849962-26e0-42f5-af19-8cd857a1e8f5)

```
1 sample - test codes written to file 002_231110_A01295_0262_AHTNWLDRX3_CEN-240827_1255_reanalysis.manifest
Launched dias batch job in project-Gq1f4q84vzJZX0YQPv88P5X0 (job-Gq6qxP04vzJQjQgx3YG5yXFk) with manifest 002_231110_A01295_0262_AHTNWLDRX3_CEN-240827_1255_reanalysis.manifest
Launched 1 Dias batch jobs
Launched jobs IDs  for dias_batch written to /home/katherine/dias_reports_bulk_reanalysis/logs/launched_jobs_240827_1255_log.json
```
The manifest only has the SNV code
![image](https://github.com/user-attachments/assets/acbb3730-0802-45e0-8601-4b0a4a0e2696)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_reports_bulk_reanalysis/62)
<!-- Reviewable:end -->
